### PR TITLE
Full unary function call support for Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # OS generated files
 .DS_Store
 .DS_Store?
+
+__pycache__/

--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	proto "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
 )
 
 // App references a deployed Modal App.
@@ -31,12 +31,12 @@ type SandboxOptions struct {
 func AppLookup(ctx context.Context, name string, options LookupOptions) (*App, error) {
 	ctx = clientContext(ctx)
 
-	creationType := proto.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
+	creationType := pb.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
 	if options.CreateIfMissing {
-		creationType = proto.ObjectCreationType_OBJECT_CREATION_TYPE_CREATE_IF_MISSING
+		creationType = pb.ObjectCreationType_OBJECT_CREATION_TYPE_CREATE_IF_MISSING
 	}
 
-	resp, err := client.AppGetOrCreate(ctx, proto.AppGetOrCreateRequest_builder{
+	resp, err := client.AppGetOrCreate(ctx, pb.AppGetOrCreateRequest_builder{
 		AppName:            name,
 		EnvironmentName:    environmentName(options.Environment),
 		ObjectCreationType: creationType,
@@ -51,16 +51,16 @@ func AppLookup(ctx context.Context, name string, options LookupOptions) (*App, e
 
 // CreateSandbox creates a new Sandbox in the App with the specified image and options.
 func (app *App) CreateSandbox(image *Image, options SandboxOptions) (*Sandbox, error) {
-	createResp, err := client.SandboxCreate(app.ctx, proto.SandboxCreateRequest_builder{
+	createResp, err := client.SandboxCreate(app.ctx, pb.SandboxCreateRequest_builder{
 		AppId: app.AppId,
-		Definition: proto.Sandbox_builder{
+		Definition: pb.Sandbox_builder{
 			EntrypointArgs: options.Command,
 			ImageId:        image.ImageId,
 			TimeoutSecs:    uint32(options.Timeout.Seconds()),
-			NetworkAccess: proto.NetworkAccess_builder{
-				NetworkAccessType: proto.NetworkAccess_OPEN,
+			NetworkAccess: pb.NetworkAccess_builder{
+				NetworkAccessType: pb.NetworkAccess_OPEN,
 			}.Build(),
-			Resources: proto.Resources_builder{
+			Resources: pb.Resources_builder{
 				MilliCpu: uint32(1000 * options.CPU),
 				MemoryMb: uint32(options.Memory),
 			}.Build(),

--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	proto "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
 )
 
 // timeoutCallOption carries a per-RPC absolute timeout.
@@ -68,7 +68,7 @@ var defaultConfig config
 // defaultProfile is resolved at package init from MODAL_PROFILE, ~/.modal.toml, etc.
 var defaultProfile Profile
 
-var client proto.ModalClientClient
+var client pb.ModalClientClient
 
 func init() {
 	var err error
@@ -86,7 +86,7 @@ func init() {
 
 // newClient dials api.modal.com with auth/timeout/retry interceptors installed.
 // It returns (conn, stub). Close the conn when done.
-func newClient(profile Profile) (*grpc.ClientConn, proto.ModalClientClient, error) {
+func newClient(profile Profile) (*grpc.ClientConn, pb.ModalClientClient, error) {
 	var target string
 	var creds credentials.TransportCredentials
 	if strings.HasPrefix(profile.ServerURL, "https://") {
@@ -114,12 +114,12 @@ func newClient(profile Profile) (*grpc.ClientConn, proto.ModalClientClient, erro
 	if err != nil {
 		return nil, nil, err
 	}
-	return conn, proto.NewModalClientClient(conn), nil
+	return conn, pb.NewModalClientClient(conn), nil
 }
 
 // clientContext returns a context with the default profile's auth headers.
 func clientContext(ctx context.Context) context.Context {
-	clientType := strconv.Itoa(int(proto.ClientType_CLIENT_TYPE_LIBMODAL))
+	clientType := strconv.Itoa(int(pb.ClientType_CLIENT_TYPE_LIBMODAL))
 	return metadata.AppendToOutgoingContext(
 		ctx,
 		"x-modal-client-type", clientType,

--- a/modal-go/errors.go
+++ b/modal-go/errors.go
@@ -1,0 +1,30 @@
+package modal
+
+// errors.go defines common error types for the public API.
+
+// TimeoutError is returned when a function execution exceeds the allowed time limit.
+type TimeoutError struct {
+	Exception string
+}
+
+func (e TimeoutError) Error() string {
+	return "TimeoutError: " + e.Exception
+}
+
+// RemoteError represents an error on the Modal server, or a Python exception.
+type RemoteError struct {
+	Exception string
+}
+
+func (e RemoteError) Error() string {
+	return "RemoteError: " + e.Exception
+}
+
+// InternalFailure is a retryable internal error from Modal.
+type InternalFailure struct {
+	Exception string
+}
+
+func (e InternalFailure) Error() string {
+	return "InternalFailure: " + e.Exception
+}

--- a/modal-go/proto/modal_proto/api.pb.go
+++ b/modal-go/proto/modal_proto/api.pb.go
@@ -4,7 +4,7 @@
 // 	protoc        v3.21.6
 // source: modal_proto/api.proto
 
-package proto
+package pb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"

--- a/modal-go/proto/modal_proto/api_grpc.pb.go
+++ b/modal-go/proto/modal_proto/api_grpc.pb.go
@@ -4,7 +4,7 @@
 // - protoc             v3.21.6
 // source: modal_proto/api.proto
 
-package proto
+package pb
 
 import (
 	context "context"

--- a/modal-go/proto/modal_proto/options.pb.go
+++ b/modal-go/proto/modal_proto/options.pb.go
@@ -8,7 +8,7 @@
 // 	protoc        v3.21.6
 // source: modal_proto/options.proto
 
-package proto
+package pb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"

--- a/modal-go/scripts/gen-proto.sh
+++ b/modal-go/scripts/gen-proto.sh
@@ -8,3 +8,6 @@ protoc \
   --go-grpc_out=paths=source_relative:proto \
   --proto_path=../modal-client \
   ../modal-client/modal_proto/*.proto
+
+# Find all 'package proto' declarations and replace with 'package pb'
+find . -type f -name '*.go' -exec sed -i 's/^package proto$/package pb/' {} +

--- a/modal-go/test/function_test.go
+++ b/modal-go/test/function_test.go
@@ -12,20 +12,19 @@ func TestFunctionCall(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	function, err := modal.FunctionLookup(context.Background(), "libmodal-test", "libmodal_function_test", modal.LookupOptions{Environment: "luis-dev"})
+	function, err := modal.FunctionLookup(
+		context.Background(),
+		"libmodal-test-support", "echo_string", modal.LookupOptions{},
+	)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	// Represent Python args and kwargs.
-	args := []interface{}{}
-	kwargs := map[string]interface{}{
-		"s": "hello",
-	}
-	result, err := function.Remote(context.Background(), args, kwargs)
+	// Represent Python kwargs.
+	result, err := function.Remote(context.Background(), nil, map[string]any{"s": "hello"})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.BeEquivalentTo("output: hello"))
 
-	// Parse the result as a string using type assertion.
-	resultString, ok := result.(string)
-	g.Expect(ok).Should(gomega.BeTrueBecause("output should be a string"))
-	g.Expect(resultString).Should(gomega.BeEquivalentTo("output: hello"))
-
+	// Try the same, but with args.
+	result, err = function.Remote(context.Background(), []any{"hello"}, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.BeEquivalentTo("output: hello"))
 }


### PR DESCRIPTION
- Poll in loop if it takes >55 seconds
- Handle errors in function results, add specific error struct definitions to Go
- Rename `proto` to `pb` so it doesn't conflict with `google/protobuf`
- Fix `FinalInput: true` stopping the container