### PR TITLE
Implements Cls lookups in Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .DS_Store
 .DS_Store?
 
-__pycache__/
+**/__pycache__/*
+**/venv/*
+

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -15,11 +15,13 @@ type Cls struct {
 	methods           map[string]*Function
 	schema            []*pb.ClassParameterSpec // schema for parameters used in init
 	serviceFunctionId string
+	initialized       bool
 	ctx               context.Context
 }
 
 // Creates parametrized instnace of Cls.
 func (c *Cls) Instance(kwargs map[string]any) (*Cls, error) {
+	c.initialized = true
 	if len(c.schema) == 0 {
 		return c, nil
 	} else {
@@ -82,8 +84,11 @@ func (c *Cls) Instance(kwargs map[string]any) (*Cls, error) {
 // Method returns the Function with the given name.
 // It returns an error if the Cls is not initialized or if the method doesn't exist.
 func (c *Cls) Method(name string) (*Function, error) {
-	if c.methods == nil {
+	if !c.initialized {
 		return nil, fmt.Errorf("Cls not initialized")
+	}
+	if c.methods == nil {
+		return nil, fmt.Errorf("Cls has no methods")
 	}
 
 	method, ok := c.methods[name]
@@ -161,6 +166,7 @@ func ClsLookup(ctx context.Context, appName string, name string, options LookupO
 
 	}
 
+	cls.initialized = false
 	return &cls, nil
 }
 

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -1,0 +1,73 @@
+package modal
+
+// Class lookups
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+)
+
+type Cls struct {
+	ClassId string
+	Methods map[string]*Function
+	ctx     context.Context
+}
+
+// ClsLookup looks up an existing Cls.
+func ClsLookup(ctx context.Context, appName string, name string, options LookupOptions) (*Cls, error) {
+	ctx = clientContext(ctx)
+	cls := Cls{
+		Methods: make(map[string]*Function),
+		ctx:     context.Background(),
+	}
+
+	// Lookup a class definition.
+	resp, err := client.ClassGet(ctx, pb.ClassGetRequest_builder{
+		AppName:           appName,
+		ObjectTag:         name,
+		Namespace:         pb.DeploymentNamespace_DEPLOYMENT_NAMESPACE_WORKSPACE,
+		EnvironmentName:   environmentName(options.Environment),
+		LookupPublished:   false,
+		OnlyClassFunction: true,
+	}.Build())
+
+	if err != nil {
+		return nil, err
+	}
+
+	cls.ClassId = resp.GetClassId()
+
+	// Get the class service function first
+	serviceFunctionName := fmt.Sprintf("%s.*", name)
+	serviceFunction, err := client.FunctionGet(ctx, pb.FunctionGetRequest_builder{
+		AppName:         appName,
+		ObjectTag:       serviceFunctionName,
+		Namespace:       pb.DeploymentNamespace_DEPLOYMENT_NAMESPACE_WORKSPACE,
+		EnvironmentName: environmentName(options.Environment),
+	}.Build())
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up class service function: %w", err)
+	}
+
+	// Check if we have method metadata on the class service function (v0.67+)
+	serviceFunctionHandleMetadata := serviceFunction.GetHandleMetadata()
+	if serviceFunctionHandleMetadata != nil && len(serviceFunctionHandleMetadata.GetMethodHandleMetadata()) > 0 {
+		for methodName, _ := range serviceFunctionHandleMetadata.GetMethodHandleMetadata() {
+			function := &Function{
+				FunctionId: serviceFunction.GetFunctionId(),
+				MethodName: methodName,
+				ctx:        ctx,
+			}
+			cls.Methods[methodName] = function
+		}
+	} else {
+		// Legacy approach not supported
+		return nil, fmt.Errorf("Go SDK does not support legacy class deployment (< v0.67). Please update your deployment to use Go SDK.")
+
+	}
+
+	return &cls, nil
+}

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -18,8 +18,8 @@ type Cls struct {
 	ctx               context.Context
 }
 
-// Initialize a Cls app. This is only useful when the Cls is parametrized.
-func (c *Cls) Init(kwargs map[string]any) (*Cls, error) {
+// Creates parametrized instnace of Cls.
+func (c *Cls) Instance(kwargs map[string]any) (*Cls, error) {
 	if len(c.schema) == 0 {
 		return c, nil
 	} else {

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -11,15 +11,30 @@ import (
 
 type Cls struct {
 	ClassId string
-	Methods map[string]*Function
+	methods map[string]*Function
 	ctx     context.Context
+}
+
+// Method returns the Function with the given name.
+// It returns an error if the Cls is not initialized or if the method doesn't exist.
+func (c *Cls) Method(name string) (*Function, error) {
+	if c.methods == nil {
+		return nil, fmt.Errorf("Cls not initialized")
+	}
+
+	method, ok := c.methods[name]
+	if !ok {
+		return nil, fmt.Errorf("Cls method %s not found", name)
+	}
+
+	return method, nil
 }
 
 // ClsLookup looks up an existing Cls constructing Function objects for each class method.
 func ClsLookup(ctx context.Context, appName string, name string, options LookupOptions) (*Cls, error) {
 	ctx = clientContext(ctx)
 	cls := Cls{
-		Methods: make(map[string]*Function),
+		methods: make(map[string]*Function),
 		ctx:     context.Background(),
 	}
 
@@ -58,10 +73,10 @@ func ClsLookup(ctx context.Context, appName string, name string, options LookupO
 		for methodName := range serviceFunctionHandleMetadata.GetMethodHandleMetadata() {
 			function := &Function{
 				FunctionId: serviceFunction.GetFunctionId(),
-				MethodName: methodName,
+				MethodName: &methodName,
 				ctx:        ctx,
 			}
-			cls.Methods[methodName] = function
+			cls.methods[methodName] = function
 		}
 	} else {
 		// Legacy approach not supported

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -36,9 +36,10 @@ func (c *Cls) Instance(kwargs map[string]any) (*Cls, error) {
 			name := paramSpec.GetName()
 			value, provided := kwargs[name]
 
-			// Skip if not provided and has default value
+			// Use default value if value is not provided but avaialble
+			defaultValue := paramSpec.GetHasDefault()
 			if !provided && paramSpec.GetHasDefault() {
-				continue
+				value = defaultValue
 			}
 
 			// Error if required and not provided

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -22,7 +22,7 @@ func timeNow() float64 {
 // Function references a deployed Modal Function.
 type Function struct {
 	FunctionId string
-	MethodName string // used for class methods
+	MethodName *string // used for class methods
 	ctx        context.Context
 }
 
@@ -86,7 +86,7 @@ func (function *Function) Remote(ctx context.Context, args []any, kwargs map[str
 		Input: pb.FunctionInput_builder{
 			Args:       payload.Bytes(),
 			DataFormat: pb.DataFormat_DATA_FORMAT_PICKLE,
-			MethodName: &function.MethodName,
+			MethodName: function.MethodName,
 		}.Build(),
 	}.Build()
 	functionInputs = append(functionInputs, functionInputItem)

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -22,6 +22,7 @@ func timeNow() float64 {
 // Function references a deployed Modal Function.
 type Function struct {
 	FunctionId string
+	MethodName string // used for class methods
 	ctx        context.Context
 }
 
@@ -85,6 +86,7 @@ func (function *Function) Remote(ctx context.Context, args []any, kwargs map[str
 		Input: pb.FunctionInput_builder{
 			Args:       payload.Bytes(),
 			DataFormat: pb.DataFormat_DATA_FORMAT_PICKLE,
+			MethodName: &function.MethodName,
 		}.Build(),
 	}.Build()
 	functionInputs = append(functionInputs, functionInputItem)

--- a/modal-go/test/cls_test.go
+++ b/modal-go/test/cls_test.go
@@ -18,11 +18,13 @@ func TestClsCall(t *testing.T) {
 	)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
+	instance, err := cls.Instance(nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
 	// Try accessing a non-existent method
 	function, err := cls.Method("nonexistent")
 	g.Expect(err).Should(gomega.HaveOccurred())
 
-	// Call function
 	function, err = cls.Method("echo_string")
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -36,8 +38,7 @@ func TestClsCall(t *testing.T) {
 	)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	// initialize
-	instance, err := clsParametrized.Instance(map[string]any{"name": "hello-init"})
+	instance, err = clsParametrized.Instance(map[string]any{"name": "hello-init"})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	function, err = instance.Method("echo_parameter")

--- a/modal-go/test/cls_test.go
+++ b/modal-go/test/cls_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modal-labs/libmodal/modal-go"
+	"github.com/onsi/gomega"
+)
+
+func TestClsCall(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cls, err := modal.ClsLookup(
+		context.Background(),
+		"libmodal-test-support", "EchoCls", modal.LookupOptions{
+			Environment: "libmodal",
+		},
+	)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// Call function
+	function, ok := cls.Methods["echo_string"]
+	g.Expect(ok).Should(gomega.BeTrue())
+
+	result, err := function.Remote(context.Background(), nil, map[string]any{"s": "hello"})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal("output: hello"))
+
+}

--- a/modal-go/test/cls_test.go
+++ b/modal-go/test/cls_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/modal-labs/libmodal/modal-go"
@@ -58,28 +57,13 @@ type Parameter struct {
 	Type  pb.ParameterType
 }
 
-func (p *Parameter) EncodeValue() (*pb.ClassParameterValue, error) {
-	switch v := p.Value.(type) {
-	case string:
-		return modal.EncodeParameterValue(p.Name, v, p.Type)
-	case int:
-		return modal.EncodeParameterValue(p.Name, v, p.Type)
-	case bool:
-		return modal.EncodeParameterValue(p.Name, v, p.Type)
-	case []byte:
-		return modal.EncodeParameterValue(p.Name, v, p.Type)
-	default:
-		return nil, fmt.Errorf("unsupported parameter type: %T", p.Value)
-	}
-}
-
 func serializeParameterSet(params []Parameter) ([]byte, error) {
 	paramSet := pb.ClassParameterSet_builder{
 		Parameters: []*pb.ClassParameterValue{},
 	}.Build()
 
 	for _, param := range params {
-		serializedParam, err := param.EncodeValue()
+		serializedParam, err := modal.EncodeParameterValue(param.Name, param.Value, param.Type)
 		if err != nil {
 			return nil, err
 		}

--- a/modal-go/test/cls_test.go
+++ b/modal-go/test/cls_test.go
@@ -37,10 +37,10 @@ func TestClsCall(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	// initialize
-	clsInitialized, err := clsParametrized.Init(map[string]any{"name": "hello-init"})
+	instance, err := clsParametrized.Instance(map[string]any{"name": "hello-init"})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	function, err = clsInitialized.Method("echo_parameter")
+	function, err = instance.Method("echo_parameter")
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	result, err = function.Remote(context.Background(), nil, nil)

--- a/modal-go/test/cls_test.go
+++ b/modal-go/test/cls_test.go
@@ -14,15 +14,17 @@ func TestClsCall(t *testing.T) {
 
 	cls, err := modal.ClsLookup(
 		context.Background(),
-		"libmodal-test-support", "EchoCls", modal.LookupOptions{
-			Environment: "libmodal",
-		},
+		"libmodal-test-support", "EchoCls", modal.LookupOptions{},
 	)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
+	// Try accessing a non-existent method
+	function, err := cls.Method("nonexistent")
+	g.Expect(err).Should(gomega.HaveOccurred())
+
 	// Call function
-	function, ok := cls.Methods["echo_string"]
-	g.Expect(ok).Should(gomega.BeTrue())
+	function, err = cls.Method("echo_string")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	result, err := function.Remote(context.Background(), nil, map[string]any{"s": "hello"})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/modal-go/test/cls_test.go
+++ b/modal-go/test/cls_test.go
@@ -30,4 +30,19 @@ func TestClsCall(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(result).Should(gomega.Equal("output: hello"))
 
+	clsParametrized, err := modal.ClsLookup(
+		context.Background(),
+		"libmodal-test-support", "EchoClsParametrized", modal.LookupOptions{},
+	)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// initialize
+	clsInitialized, err := clsParametrized.Init(map[string]any{"name": "hello-init"})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	function, err = clsInitialized.Method("echo_parameter")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	result, err = function.Remote(context.Background(), nil, nil)
+	g.Expect(result).Should(gomega.Equal("output: hello-init"))
 }

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -13,3 +13,11 @@ class EchoCls:
     @modal.method()
     def echo_string(self, s: str) -> str:
         return "output: " + s
+
+@app.cls(scaledown_window=60 * 60)
+class EchoClsParametrized:
+    name: str = modal.parameter(default="test")
+  
+    @modal.method()
+    def echo_parameter(self) -> str:
+        return "output: " + self.name

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -7,3 +7,9 @@ app = modal.App("libmodal-test-support")
 @app.function(min_containers=1)
 def echo_string(s: str) -> str:
     return "output: " + s
+
+@app.cls(min_containers=1)
+class EchoCls:
+    @modal.method()
+    def echo_string(self, s: str) -> str:
+        return "output: " + s


### PR DESCRIPTION
Adds support for looking up Modal Cls and invoking its methods. 

```go

// Lookup class
cls, _ := modal.ClsLookup(
	context.Background(),
	"libmodal-test-support", "EchoClsParametrized", modal.LookupOptions{},
)
instance, _ := cls.Instance(map[string]any{"name": "hello-init"})

// Call method
function, _ = instance.Method("echo_parameter")
result, _ = function.Remote(context.Background(), nil, nil)
```

The interface `Methods map[string]*Function` is inelegant in Go but natural to Pythonistas. Open to ideas on how to make this better. 