### PR TITLE
Support blob upload for calling functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Both client libraries are pre-1.0, and they have separate versioning.
+
+## Unreleased
+
+- Support calling remote functions with arguments greater than 2 MiB in byte payload size.
+
+## modal-js/v0.3.2, modal-go/v0.0.3
+
+- First public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ Both client libraries are pre-1.0, and they have separate versioning.
 ## modal-js/v0.3.2, modal-go/v0.0.3
 
 - First public release
+- Basic `Function`, `Sandbox`, `Image`, and `ContainerProcess` support

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -5,6 +5,9 @@ package modal
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +17,9 @@ import (
 	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
 	"google.golang.org/protobuf/proto"
 )
+
+// From: modal/_utils/blob_utils.py
+const maxObjectSizeBytes = 2 * 1024 * 1024 // 2 MiB
 
 func timeNow() float64 {
 	return float64(time.Now().UnixNano()) / 1e9
@@ -78,12 +84,24 @@ func (function *Function) Remote(ctx context.Context, args []any, kwargs map[str
 		return nil, err
 	}
 
+	argsBytes := payload.Bytes()
+	var argsBlobId *string
+	if payload.Len() > maxObjectSizeBytes {
+		blobId, err := blobUpload(ctx, argsBytes)
+		if err != nil {
+			return nil, err
+		}
+		argsBytes = nil
+		argsBlobId = &blobId
+	}
+
 	// Single input sync invocation
 	var functionInputs []*pb.FunctionPutInputsItem
 	functionInputItem := pb.FunctionPutInputsItem_builder{
 		Idx: 0,
 		Input: pb.FunctionInput_builder{
-			Args:       payload.Bytes(),
+			Args:       argsBytes,
+			ArgsBlobId: argsBlobId,
 			DataFormat: pb.DataFormat_DATA_FORMAT_PICKLE,
 		}.Build(),
 	}.Build()
@@ -155,6 +173,49 @@ func processResult(ctx context.Context, result *pb.GenericResult, dataFormat pb.
 	}
 
 	return deserializeDataFormat(data, dataFormat)
+}
+
+// blobUpload uploads a blob to S3 and returns its ID.
+func blobUpload(ctx context.Context, data []byte) (string, error) {
+	md5sum := md5.Sum(data)
+	sha256sum := sha256.Sum256(data)
+	contentMd5 := base64.StdEncoding.EncodeToString(md5sum[:])
+	contentSha256 := base64.StdEncoding.EncodeToString(sha256sum[:])
+
+	resp, err := client.BlobCreate(ctx, pb.BlobCreateRequest_builder{
+		ContentMd5:          contentMd5,
+		ContentSha256Base64: contentSha256,
+		ContentLength:       int64(len(data)),
+	}.Build())
+	if err != nil {
+		return "", fmt.Errorf("failed to create blob: %w", err)
+	}
+
+	switch resp.WhichUploadTypeOneof() {
+	case pb.BlobCreateResponse_Multipart_case:
+		return "", fmt.Errorf("function input size exceeds multipart upload threshold, unsupported by this SDK version")
+
+	case pb.BlobCreateResponse_UploadUrl_case:
+		req, err := http.NewRequest("PUT", resp.GetUploadUrl(), bytes.NewReader(data))
+		if err != nil {
+			return "", fmt.Errorf("failed to create upload request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("Content-MD5", contentMd5)
+		uploadResp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to upload blob: %w", err)
+		}
+		defer uploadResp.Body.Close()
+		if uploadResp.StatusCode < 200 || uploadResp.StatusCode >= 300 {
+			return "", fmt.Errorf("failed blob upload: %s", uploadResp.Status)
+		}
+		// Skip client-side ETag header validation for now (MD5 checksum).
+		return resp.GetBlobId(), nil
+
+	default:
+		return "", fmt.Errorf("missing upload URL in BlobCreate response")
+	}
 }
 
 // blobDownload downloads a blob by its ID.

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -175,7 +175,7 @@ func processResult(ctx context.Context, result *pb.GenericResult, dataFormat pb.
 	return deserializeDataFormat(data, dataFormat)
 }
 
-// blobUpload uploads a blob to S3 and returns its ID.
+// blobUpload uploads a blob to storage and returns its ID.
 func blobUpload(ctx context.Context, data []byte) (string, error) {
 	md5sum := md5.Sum(data)
 	sha256sum := sha256.Sum256(data)

--- a/modal-go/test/function_test.go
+++ b/modal-go/test/function_test.go
@@ -28,3 +28,20 @@ func TestFunctionCall(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(result).Should(gomega.Equal("output: hello"))
 }
+
+func TestFunctionCallLargeInput(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	function, err := modal.FunctionLookup(
+		context.Background(),
+		"libmodal-test-support", "bytelength", modal.LookupOptions{},
+	)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	len := 3 * 1000 * 1000 // More than 2 MiB, limit to offload to S3
+	input := make([]byte, len)
+	result, err := function.Remote(context.Background(), []any{input}, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal(int64(len)))
+}

--- a/modal-go/test/function_test.go
+++ b/modal-go/test/function_test.go
@@ -39,7 +39,7 @@ func TestFunctionCallLargeInput(t *testing.T) {
 	)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	len := 3 * 1000 * 1000 // More than 2 MiB, limit to offload to S3
+	len := 3 * 1000 * 1000 // More than 2 MiB, offload to blob storage
 	input := make([]byte, len)
 	result, err := function.Remote(context.Background(), []any{input}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -1,5 +1,7 @@
 // Function calls and invocations, to be used with Modal Functions.
 
+import { createHash } from "crypto";
+
 import {
   DataFormat,
   DeploymentNamespace,
@@ -14,6 +16,9 @@ import { client } from "./client";
 import { environmentName } from "./config";
 import { InternalFailure, RemoteError, TimeoutError } from "./errors";
 import { dumps, loads } from "./pickle";
+
+// From: modal/_utils/blob_utils.py
+const maxObjectSizeBytes = 2 * 1024 * 1024; // 2 MiB
 
 function timeNow() {
   return Date.now() / 1e3;
@@ -48,23 +53,27 @@ export class Function_ {
   ): Promise<any> {
     const payload = dumps([args, kwargs]);
 
-    // Single input sync invocation
-    const functionInputs = [
-      {
-        idx: 0,
-        input: {
-          args: payload,
-          dataFormat: DataFormat.DATA_FORMAT_PICKLE,
-        },
-      },
-    ];
+    let argsBlobId: string | undefined = undefined;
+    if (payload.length > maxObjectSizeBytes) {
+      argsBlobId = await blobUpload(payload);
+    }
 
+    // Single input sync invocation
     const functionMapResponse = await client.functionMap({
       functionId: this.functionId,
       functionCallType: FunctionCallType.FUNCTION_CALL_TYPE_UNARY,
       functionCallInvocationType:
         FunctionCallInvocationType.FUNCTION_CALL_INVOCATION_TYPE_SYNC,
-      pipelinedInputs: functionInputs,
+      pipelinedInputs: [
+        {
+          idx: 0,
+          input: {
+            args: argsBlobId ? undefined : payload,
+            argsBlobId,
+            dataFormat: DataFormat.DATA_FORMAT_PICKLE,
+          },
+        },
+      ],
     });
 
     while (true) {
@@ -113,7 +122,38 @@ async function processResult(
       throw new RemoteError(`Remote error: ${result.exception}`);
   }
 
-  return deserializeDataFormat(result.data, dataFormat);
+  return deserializeDataFormat(data, dataFormat);
+}
+
+async function blobUpload(data: Uint8Array): Promise<string> {
+  const contentMd5 = createHash("md5").update(data).digest("base64");
+  const contentSha256 = createHash("sha256").update(data).digest("base64");
+  const resp = await client.blobCreate({
+    contentMd5,
+    contentSha256Base64: contentSha256,
+    contentLength: data.length,
+  });
+  if (resp.multipart) {
+    throw new Error(
+      "Function input size exceeds multipart upload threshold, unsupported by this SDK version",
+    );
+  } else if (resp.uploadUrl) {
+    const uploadResp = await fetch(resp.uploadUrl, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "Content-MD5": contentMd5,
+      },
+      body: data,
+    });
+    if (uploadResp.status < 200 || uploadResp.status >= 300) {
+      throw new Error(`Failed blob upload: ${uploadResp.statusText}`);
+    }
+    // Skip client-side ETag header validation for now (MD5 checksum).
+    return resp.blobId;
+  } else {
+    throw new Error("Missing upload URL in BlobCreate response");
+  }
 }
 
 async function blobDownload(blobId: string): Promise<Uint8Array> {

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -1,6 +1,6 @@
 // Function calls and invocations, to be used with Modal Functions.
 
-import { createHash } from "crypto";
+import { createHash } from "node:crypto";
 
 import {
   DataFormat,

--- a/modal-js/test/function.test.ts
+++ b/modal-js/test/function.test.ts
@@ -15,3 +15,14 @@ test("FunctionCall", async () => {
   const resultArgs = await function_.remote(["hello"]);
   expect(resultArgs).toBe("output: hello");
 });
+
+test("FunctionCallLargeInput", async () => {
+  const function_ = await Function_.lookup(
+    "libmodal-test-support",
+    "bytelength",
+  );
+  const len = 3 * 1000 * 1000; // More than 2 MiB, limit to offload to S3
+  const input = new Uint8Array(len);
+  const result = await function_.remote([input]);
+  expect(result).toBe(len);
+});

--- a/modal-js/test/function.test.ts
+++ b/modal-js/test/function.test.ts
@@ -21,7 +21,7 @@ test("FunctionCallLargeInput", async () => {
     "libmodal-test-support",
     "bytelength",
   );
-  const len = 3 * 1000 * 1000; // More than 2 MiB, limit to offload to S3
+  const len = 3 * 1000 * 1000; // More than 2 MiB, offload to blob storage
   const input = new Uint8Array(len);
   const result = await function_.remote([input]);
   expect(result).toBe(len);

--- a/modal-js/vitest.config.ts
+++ b/modal-js/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     maxConcurrency: 10,
     slowTestThreshold: 5_000,
-    testTimeout: 15_000,
+    testTimeout: 20_000,
   },
 });

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -7,3 +7,8 @@ app = modal.App("libmodal-test-support")
 @app.function(min_containers=1)
 def echo_string(s: str) -> str:
     return "output: " + s
+
+
+@app.function(min_containers=1)
+def bytelength(buf: bytes) -> int:
+    return len(buf)


### PR DESCRIPTION
In previous versions of libmodal, we did not support inputs greater than 2 MiB. This returned an error from the server. This PR adds support for inputs larger than 2 MiB via S3 offload.

```
 FAIL  test/function.test.ts > FunctionCallLargeInput
ClientError: /modal.client.ModalClient/FunctionMap INVALID_ARGUMENT: The size of input 0 is 2.00MiB, which exceeds the maximum allowed size of 2.00MiB. Please reduce the size of the input and try again.
```

Multipart blob upload for calling functions is still not supported yet. This is currently set on the server for inputs greater than 128 MiB.

Also starting a changelog with this commit. Will probably bump modal-js to v0.3.3 and modal-go to v0.0.4 after this. It's backwards-compatible, modal-go is pretty unstable though so we don't have a patch version for it yet.