### PR TITLE
Implements `Spawn` in the Go SDK

### DIFF
--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -134,10 +134,11 @@ func (f *Function) Remote(args []any, kwargs map[string]any) (any, error) {
 	}
 
 	functionCallId := functionMapResponse.GetFunctionCallId()
-	return pollForOutput(f.ctx, functionCallId)
+	return pollFunctionOutput(f.ctx, functionCallId)
 }
 
-func pollForOutput(ctx context.Context, functionCallId string) (any, error) {
+// Poll for ouputs for a given FunctionCall ID
+func pollFunctionOutput(ctx context.Context, functionCallId string) (any, error) {
 	for {
 		response, err := client.FunctionGetOutputs(ctx, pb.FunctionGetOutputsRequest_builder{
 			FunctionCallId: functionCallId,

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -169,7 +169,6 @@ func (f *Function) Spawn(args []any, kwargs map[string]any) (*FunctionCall, erro
 	}
 	functionCall := FunctionCall{
 		FunctionCallId: functionMapResponse.GetFunctionCallId(),
-		function:       f,
 		ctx:            f.ctx,
 	}
 	return &functionCall, nil

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -134,7 +134,7 @@ func (f *Function) Remote(args []any, kwargs map[string]any) (any, error) {
 	}
 
 	functionCallId := functionMapResponse.GetFunctionCallId()
-	return pollForOutput(functionCallId)
+	return pollForOutput(f.ctx, functionCallId)
 }
 
 func pollForOutput(ctx context.Context, functionCallId string) (any, error) {

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -1,0 +1,43 @@
+package modal
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+)
+
+// FunctionCall references a Modal function call.
+type FunctionCall struct {
+	FunctionCallId string
+	function       *Function
+	ctx            context.Context
+}
+
+// Gets the ouptut for a FunctionCall
+func (fc *FunctionCall) Get() (any, error) {
+	return pollForOutput(fc.ctx, fc.FunctionCallId)
+}
+
+// Cancel a FunctionCall
+func (fc *FunctionCall) Cancel(terminateContainers bool) error {
+	_, err := client.FunctionCallCancel(fc.ctx, pb.FunctionCallCancelRequest_builder{
+		FunctionCallId:      fc.FunctionCallId,
+		TerminateContainers: terminateContainers,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("FunctionCallCancel failed: %v", err)
+	}
+
+	return nil
+}
+
+// Lookup a FunctionCall
+func FunctionCallLookup(ctx context.Context, functionCallId string) (FunctionCall, error) {
+	ctx = clientContext(ctx)
+	functionCall := FunctionCall{
+		FunctionCallId: functionCallId,
+		ctx:            ctx,
+	}
+	return functionCall, nil
+}

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -7,16 +7,27 @@ import (
 	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
 )
 
-// FunctionCall references a Modal function call.
+// FunctionCall references a Modal Function Call. Function Calls are
+// Function invocations with a given input. They can be consumed
+// asynchronously (see Get()) or cancelled (see Cancel()).
 type FunctionCall struct {
 	FunctionCallId string
-	function       *Function
 	ctx            context.Context
 }
 
 // Gets the ouptut for a FunctionCall
 func (fc *FunctionCall) Get() (any, error) {
 	return pollForOutput(fc.ctx, fc.FunctionCallId)
+}
+
+// Lookup a FunctionCall
+func FunctionCallLookup(ctx context.Context, functionCallId string) (*FunctionCall, error) {
+	ctx = clientContext(ctx)
+	functionCall := FunctionCall{
+		FunctionCallId: functionCallId,
+		ctx:            ctx,
+	}
+	return &functionCall, nil
 }
 
 // Cancel a FunctionCall
@@ -30,14 +41,4 @@ func (fc *FunctionCall) Cancel(terminateContainers bool) error {
 	}
 
 	return nil
-}
-
-// Lookup a FunctionCall
-func FunctionCallLookup(ctx context.Context, functionCallId string) (*FunctionCall, error) {
-	ctx = clientContext(ctx)
-	functionCall := FunctionCall{
-		FunctionCallId: functionCallId,
-		ctx:            ctx,
-	}
-	return &functionCall, nil
 }

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -33,11 +33,11 @@ func (fc *FunctionCall) Cancel(terminateContainers bool) error {
 }
 
 // Lookup a FunctionCall
-func FunctionCallLookup(ctx context.Context, functionCallId string) (FunctionCall, error) {
+func FunctionCallLookup(ctx context.Context, functionCallId string) (*FunctionCall, error) {
 	ctx = clientContext(ctx)
 	functionCall := FunctionCall{
 		FunctionCallId: functionCallId,
 		ctx:            ctx,
 	}
-	return functionCall, nil
+	return &functionCall, nil
 }

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -17,7 +17,7 @@ type FunctionCall struct {
 
 // Gets the ouptut for a FunctionCall
 func (fc *FunctionCall) Get() (any, error) {
-	return pollForOutput(fc.ctx, fc.FunctionCallId)
+	return pollFunctionOutput(fc.ctx, fc.FunctionCallId)
 }
 
 // Lookup a FunctionCall

--- a/modal-go/test/function_call_test.go
+++ b/modal-go/test/function_call_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modal-labs/libmodal/modal-go"
+	"github.com/onsi/gomega"
+)
+
+func TestFunctionSpawn(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	function, err := modal.FunctionLookup(
+		context.Background(),
+		"libmodal-test-support", "echo_string", modal.LookupOptions{},
+	)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// Call function using spawn
+	functionCall, err := function.Spawn(nil, map[string]any{"s": "hello"})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// Get input later
+	result, err := functionCall.Get()
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal("output: hello"))
+
+	// Create FunctionCall instance and get output again
+	functionCall, err = modal.FunctionCallLookup(context.Background(), functionCall.FunctionCallId)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	result, err = functionCall.Get()
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal("output: hello"))
+
+}

--- a/modal-go/test/function_call_test.go
+++ b/modal-go/test/function_call_test.go
@@ -35,4 +35,23 @@ func TestFunctionSpawn(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(result).Should(gomega.Equal("output: hello"))
 
+	// Get function that
+	functionSleep, err := modal.FunctionLookup(
+		context.Background(),
+		"libmodal-test-support", "sleep", modal.LookupOptions{},
+	)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	functionCall, err = functionSleep.Spawn(nil, map[string]any{"t": 5})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// Cancel function call
+	terminateContainers := false // leave test containers running
+	err = functionCall.Cancel(terminateContainers)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// Attempting to get cancelled input fails
+	_, err = functionCall.Get()
+	g.Expect(err).Should(gomega.HaveOccurred())
+
 }

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -1,4 +1,5 @@
 import modal
+import time
 
 
 app = modal.App("libmodal-test-support")
@@ -8,6 +9,9 @@ app = modal.App("libmodal-test-support")
 def echo_string(s: str) -> str:
     return "output: " + s
 
+@app.function(min_containers=1)
+def sleep(t: int) -> None:
+    time.sleep(t)
 
 @app.function(min_containers=1)
 def bytelength(buf: bytes) -> int:


### PR DESCRIPTION
The Go SDK now supports spawn as follows:

```go
function, err := modal.FunctionLookup(
	context.Background(),
	"libmodal-test-support", "echo_string", modal.LookupOptions{},
)

// Call function using spawn
functionCall, err := function.Spawn(nil, map[string]any{"s": "hello"})

// Get input later
result, err := functionCall.Get()

// Or cancel Function Call
result, err := functionCall.Cancel()
```

Internally, `Remote()` is effectively the same as `Spawn()` + `Get()`. 