### PR TITLE
Add support for calling input plane functions

### DIFF
--- a/modal-go/test/function_call_test.go
+++ b/modal-go/test/function_call_test.go
@@ -30,7 +30,7 @@ func TestFunctionSpawn(t *testing.T) {
 	g.Expect(result).Should(gomega.Equal("output: hello"))
 
 	// Create FunctionCall instance and get output again.
-	functionCall, err = modal.FunctionCallFromId(context.Background(), functionCall.FunctionCallId)
+	functionCall, err = modal.FunctionCallFromPoller(context.Background(), functionCall.FunctionOutputPoller)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	result, err = functionCall.Get(nil)

--- a/modal-go/test/function_test.go
+++ b/modal-go/test/function_test.go
@@ -40,6 +40,21 @@ func TestFunctionCallLargeInput(t *testing.T) {
 	g.Expect(result).Should(gomega.Equal(int64(len)))
 }
 
+func TestFunctionCallInputPlane(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	function, err := modal.FunctionLookup(
+		context.Background(),
+		"libmodal-test-support", "input_plane", modal.LookupOptions{},
+	)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	result, err := function.Remote([]any{"hello"}, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal("output: hello"))
+}
+
 func TestFunctionNotFound(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -224,7 +224,9 @@ const retryMiddleware: ClientMiddleware<RetryOptions> =
 const clients: Record<string, ReturnType<typeof createClient>> = {};
 
 /** Returns a client for the given server URL, creating it if it doesn't exist. */
-export const getOrCreateClient = (serverURL: string): ReturnType<typeof createClient> => {
+export const getOrCreateClient = (
+  serverURL: string,
+): ReturnType<typeof createClient> => {
   if (serverURL in clients) {
     return clients[serverURL];
   }
@@ -246,7 +248,7 @@ const createClient = (serverURL: string) => {
     .use(retryMiddleware)
     .use(timeoutMiddleware)
     .create(ModalClientDefinition, channel);
-}
+};
 
 /** The default Modal client that talks to the control plane. */
 export const client = getOrCreateClient(profile.serverUrl);

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -13,6 +13,8 @@ import {
 import { ClientType, ModalClientDefinition } from "../proto/modal_proto/api";
 import { type Profile, profile } from "./config";
 
+let modalAuthToken: string | undefined;
+
 /** gRPC client middleware to add auth token to request. */
 function authMiddleware(profile: Profile): ClientMiddleware {
   return async function* authMiddleware<Request, Response>(
@@ -27,6 +29,31 @@ function authMiddleware(profile: Profile): ClientMiddleware {
     options.metadata.set("x-modal-client-version", "1.0.0"); // CLIENT VERSION: Behaves like this Python SDK version
     options.metadata.set("x-modal-token-id", profile.tokenId);
     options.metadata.set("x-modal-token-secret", profile.tokenSecret);
+    if (modalAuthToken) {
+      options.metadata.set("x-modal-auth-token", modalAuthToken);
+    }
+
+    const prevOnHeader = options.onHeader;
+    options.onHeader = (header) => {
+      const token = header.get("x-modal-auth-token");
+      if (token) {
+        modalAuthToken = token;
+      }
+      if (prevOnHeader) {
+        prevOnHeader(header);
+      }
+    };
+    const prevOnTrailer = options.onTrailer;
+    options.onTrailer = (trailer) => {
+      const token = trailer.get("x-modal-auth-token");
+      if (token) {
+        modalAuthToken = token;
+      }
+      if (prevOnTrailer) {
+        prevOnTrailer(trailer);
+      }
+    };
+
     return yield* call.next(call.request, options);
   };
 }
@@ -190,15 +217,36 @@ const retryMiddleware: ClientMiddleware<RetryOptions> =
     }
   };
 
-// Ref: https://github.com/modal-labs/modal-client/blob/main/modal/_utils/grpc_utils.py
-const channel = createChannel(profile.serverUrl, undefined, {
-  "grpc.max_receive_message_length": 100 * 1024 * 1024,
-  "grpc.max_send_message_length": 100 * 1024 * 1024,
-  "grpc-node.flow_control_window": 64 * 1024 * 1024,
-});
+/**
+ * Map of server URL => client.
+ * The us-east client talks to the control plane; all other clients talk to input planes.
+ */
+const clients: Record<string, ReturnType<typeof createClient>> = {};
 
-export const client = createClientFactory()
-  .use(authMiddleware(profile))
-  .use(retryMiddleware)
-  .use(timeoutMiddleware)
-  .create(ModalClientDefinition, channel);
+/** Returns a client for the given server URL, creating it if it doesn't exist. */
+export const getOrCreateClient = (serverURL: string): ReturnType<typeof createClient> => {
+  if (serverURL in clients) {
+    return clients[serverURL];
+  }
+
+  clients[serverURL] = createClient(serverURL);
+  return clients[serverURL];
+};
+
+const createClient = (serverURL: string) => {
+  // Ref: https://github.com/modal-labs/modal-client/blob/main/modal/_utils/grpc_utils.py
+  const channel = createChannel(serverURL, undefined, {
+    "grpc.max_receive_message_length": 100 * 1024 * 1024,
+    "grpc.max_send_message_length": 100 * 1024 * 1024,
+    "grpc-node.flow_control_window": 64 * 1024 * 1024,
+  });
+
+  return createClientFactory()
+    .use(authMiddleware(profile))
+    .use(retryMiddleware)
+    .use(timeoutMiddleware)
+    .create(ModalClientDefinition, channel);
+}
+
+/** The default Modal client that talks to the control plane. */
+export const client = getOrCreateClient(profile.serverUrl);

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -6,6 +6,7 @@ import type {
   FunctionGetOutputsItem,
   FunctionPutInputsItem,
   GenericResult,
+  ModalClientClient,
 } from "../proto/modal_proto/api";
 import {
   DataFormat,
@@ -178,24 +179,24 @@ export class Function_ {
 export class FunctionOutputPoller {
   functionCallId?: string;
   attemptToken?: string;
-  client: any;
+  client: ModalClientClient;
 
   static fromFunctionCallId(
-    client: any,
+    client: ModalClientClient,
     functionCallId: string,
   ): FunctionOutputPoller {
     return new FunctionOutputPoller(client, functionCallId, undefined);
   }
 
   static fromAttemptToken(
-    client: any,
+    client: ModalClientClient,
     attemptToken: string,
   ): FunctionOutputPoller {
     return new FunctionOutputPoller(client, undefined, attemptToken);
   }
 
   private constructor(
-    client: any,
+    client: ModalClientClient,
     functionCallId?: string,
     attemptToken?: string,
   ) {

--- a/modal-js/test/function.test.ts
+++ b/modal-js/test/function.test.ts
@@ -27,6 +27,15 @@ test("FunctionCallLargeInput", async () => {
   expect(result).toBe(len);
 });
 
+test("FunctionCallInputPlane", async () => {
+  const function_ = await Function_.lookup(
+    "libmodal-test-support",
+    "input_plane",
+  );
+  const result = await function_.remote(["hello"]);
+  expect(result).toBe("output: hello");
+});
+
 test("FunctionNotFound", async () => {
   const promise = Function_.lookup(
     "libmodal-test-support",

--- a/modal-js/test/function_call.test.ts
+++ b/modal-js/test/function_call.test.ts
@@ -9,7 +9,7 @@ test("FunctionSpawn", async () => {
 
   // Spawn function with kwargs.
   let functionCall = await function_.spawn([], { s: "hello" });
-  expect(functionCall.functionCallId).toBeDefined();
+  expect(functionCall.functionOutputPoller.functionCallId).toBeDefined();
 
   // Get results after spawn.
   let resultKwargs = await functionCall.get();
@@ -24,7 +24,7 @@ test("FunctionSpawn", async () => {
 
   // Spawn with long running input.
   functionCall = await sleep.spawn([], { t: 5 });
-  expect(functionCall.functionCallId).toBeDefined();
+  expect(functionCall.functionOutputPoller.functionCallId).toBeDefined();
 
   // Getting outputs with timeout raises error.
   const promise = functionCall.get({ timeout: 1000 }); // 1000ms

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -20,6 +20,11 @@ def bytelength(buf: bytes) -> int:
     return len(buf)
 
 
+@app.function(min_containers=1, experimental_options={"input_plane_region": "us-west"})
+def input_plane(s: str) -> str:
+    return "output: " + s
+
+
 @app.cls(min_containers=1)
 class EchoCls:
     @modal.method()

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -20,9 +20,10 @@ def bytelength(buf: bytes) -> int:
     return len(buf)
 
 
-@app.function(min_containers=1, experimental_options={"input_plane_region": "us-west"})
-def input_plane(s: str) -> str:
-    return "output: " + s
+# TODO(nathan): re-enable once input plane is enabled in prod
+# @app.function(min_containers=1, experimental_options={"input_plane_region": "us-west"})
+# def input_plane(s: str) -> str:
+#     return "output: " + s
 
 
 @app.cls(min_containers=1)

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -1,6 +1,6 @@
-import modal
 import time
 
+import modal
 
 app = modal.App("libmodal-test-support")
 
@@ -20,10 +20,9 @@ def bytelength(buf: bytes) -> int:
     return len(buf)
 
 
-# TODO(nathan): re-enable once input plane is enabled in prod
-# @app.function(min_containers=1, experimental_options={"input_plane_region": "us-west"})
-# def input_plane(s: str) -> str:
-#     return "output: " + s
+@app.function(min_containers=1, experimental_options={"input_plane_region": "us-west"})
+def input_plane(s: str) -> str:
+    return "output: " + s
 
 
 @app.cls(min_containers=1)


### PR DESCRIPTION
This PR adds `libmodal` support for calling input plane functions. This requires a few changes:

1. Support multiple `ModalClientStub`s pointing to different server URLs.
2. Propagate `x-modal-auth-token` from `FunctionGet` to the input plane RPCs.
3. Implement the new set of RPCs for the input plane.

We will need to add support for retrying internal failures next.

Note that this PR cannot be merged until we enable input plane functions in production; otherwise, the tests will fail.