### PR TITLE
Add support for reading images from AWS ECR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
-No changes yet.
+- Added support for creating images from AWS ECR with `App.imageFromAwsEcr()` (TS) / `App.ImageFromAwsEcr()` (Go).
+- Added support for accessing Modal secrets with `Secret.fromName()` (TS) / `modal.SecretFromName()` (Go).
 
 ## modal-js/v0.3.6, modal-go/v0.0.7
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Examples:
 - [Spawn a deployed function](./modal-js/examples/function-spawn.ts)
 - [Call a deployed cls](./modal-js/examples/cls-call.ts)
 - [Create a sandbox](./modal-js/examples/sandbox.ts)
+- [Create a sandbox using a private image from AWS ECR](./modal-js/examples/sandbox-private-image.ts)
 - [Execute sandbox commands](./modal-js/examples/sandbox-exec.ts)
 
 ### Go (`modal-go/`)
@@ -54,6 +55,7 @@ Examples:
 - [Spawn a deployed function](./modal-go/examples/function-spawn/main.go)
 - [Call a deployed cls](./modal-go/examples/cls-call/main.go)
 - [Create a sandbox](./modal-go/examples/sandbox/main.go)
+- [Create a sandbox using a private image from AWS ECR](./modal-go/examples/sandbox-private-image/main.go)
 - [Execute sandbox commands](./modal-go/examples/sandbox-exec/main.go)
 
 ### Python

--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -98,5 +98,13 @@ func (app *App) CreateSandbox(image *Image, options *SandboxOptions) (*Sandbox, 
 
 // ImageFromRegistry creates an Image from a registry tag.
 func (app *App) ImageFromRegistry(tag string) (*Image, error) {
-	return fromRegistryInternal(app, tag)
+	return fromRegistryInternal(app, tag, &pb.ImageRegistryConfig{})
+}
+
+// ImageFromAwsEcr creates an Image from an AWS ECR tag, and secret for auth.
+func (app *App) ImageFromAwsEcr(tag string, secret *Secret) (*Image, error) {
+	imageRegistryConfig := &pb.ImageRegistryConfig{}
+	imageRegistryConfig.SetRegistryAuthType(pb.RegistryAuthType_REGISTRY_AUTH_TYPE_AWS)
+	imageRegistryConfig.SetSecretId(secret.SecretId)
+	return fromRegistryInternal(app, tag, imageRegistryConfig)
 }

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -14,19 +14,21 @@ import (
 
 // Profile holds a fully-resolved configuration ready for use by the client.
 type Profile struct {
-	ServerURL   string // e.g. https://api.modal.com:443
-	TokenId     string
-	TokenSecret string
-	Environment string // optional
+	ServerURL           string // e.g. https://api.modal.com:443
+	TokenId             string
+	TokenSecret         string
+	Environment         string // optional
+	ImageBuilderVersion string // optional
 }
 
 // rawProfile mirrors the TOML structure on disk.
 type rawProfile struct {
-	ServerURL   string `toml:"server_url"`
-	TokenId     string `toml:"token_id"`
-	TokenSecret string `toml:"token_secret"`
-	Environment string `toml:"environment"`
-	Active      bool   `toml:"active"`
+	ServerURL           string `toml:"server_url"`
+	TokenId             string `toml:"token_id"`
+	TokenSecret         string `toml:"token_secret"`
+	Environment         string `toml:"environment"`
+	ImageBuilderVersion string `toml:"image_builder_version"`
+	Active              bool   `toml:"active"`
 }
 
 type config map[string]rawProfile
@@ -87,16 +89,18 @@ func GetProfile(name string) (Profile, error) {
 	tokenId := firstNonEmpty(os.Getenv("MODAL_TOKEN_ID"), raw.TokenId)
 	tokenSecret := firstNonEmpty(os.Getenv("MODAL_TOKEN_SECRET"), raw.TokenSecret)
 	environment := firstNonEmpty(os.Getenv("MODAL_ENVIRONMENT"), raw.Environment)
+	imageBuilderVersion := firstNonEmpty(os.Getenv("MODAL_IMAGE_BUILDER_VERSION"), raw.ImageBuilderVersion)
 
 	if tokenId == "" || tokenSecret == "" {
 		return Profile{}, fmt.Errorf("profile %q missing token_id or token_secret (env-vars take precedence)", name)
 	}
 
 	return Profile{
-		ServerURL:   serverURL,
-		TokenId:     tokenId,
-		TokenSecret: tokenSecret,
-		Environment: environment,
+		ServerURL:           serverURL,
+		TokenId:             tokenId,
+		TokenSecret:         tokenSecret,
+		Environment:         environment,
+		ImageBuilderVersion: imageBuilderVersion,
 	}, nil
 }
 
@@ -111,4 +115,8 @@ func firstNonEmpty(values ...string) string {
 
 func environmentName(environment string) string {
 	return firstNonEmpty(environment, defaultProfile.Environment)
+}
+
+func imageBuilderVersion(version string) string {
+	return firstNonEmpty(version, defaultProfile.ImageBuilderVersion)
 }

--- a/modal-go/examples/sandbox-private-image/main.go
+++ b/modal-go/examples/sandbox-private-image/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	app, err := modal.AppLookup(ctx, "libmodal-example", modal.LookupOptions{CreateIfMissing: true})
+	app, err := modal.AppLookup(ctx, "libmodal-example", &modal.LookupOptions{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to lookup or create app: %v", err)
 	}
@@ -29,7 +29,7 @@ func main() {
 		log.Fatalf("Failed to create image from registry: %v", err)
 	}
 
-	sb, err := app.CreateSandbox(image, modal.SandboxOptions{
+	sb, err := app.CreateSandbox(image, &modal.SandboxOptions{
 		Command: []string{"python", "-c", `import sys; sys.stdout.write(sys.stdin.read())`},
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-private-image/main.go
+++ b/modal-go/examples/sandbox-private-image/main.go
@@ -17,7 +17,6 @@ func main() {
 	}
 
 	secret, err := modal.SecretFromName(ctx, "aws-ecr-private-registry-test-secret", &modal.SecretFromNameOptions{
-		Environment:  "libmodal",
 		RequiredKeys: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-private-image/main.go
+++ b/modal-go/examples/sandbox-private-image/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log"
+
+	"github.com/modal-labs/libmodal/modal-go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	app, err := modal.AppLookup(ctx, "libmodal-example", modal.LookupOptions{CreateIfMissing: true})
+	if err != nil {
+		log.Fatalf("Failed to lookup or create app: %v", err)
+	}
+
+	secret, err := modal.SecretFromName(ctx, "aws-ecr-private-registry-test-secret", &modal.SecretFromNameOptions{
+		Environment:  "libmodal",
+		RequiredKeys: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
+	})
+	if err != nil {
+		log.Fatalf("Failed to get secret: %v", err)
+	}
+
+	image, err := app.ImageFromAwsEcr("459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python", secret)
+	if err != nil {
+		log.Fatalf("Failed to create image from registry: %v", err)
+	}
+
+	sb, err := app.CreateSandbox(image, modal.SandboxOptions{
+		Command: []string{"python", "-c", `import sys; sys.stdout.write(sys.stdin.read())`},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create sandbox: %v", err)
+	}
+	log.Printf("sandbox: %s\n", sb.SandboxId)
+
+	_, err = sb.Stdin.Write([]byte("this is input that should be mirrored by the Python one-liner"))
+	if err != nil {
+		log.Fatalf("Failed to write to sandbox stdin: %v", err)
+	}
+	err = sb.Stdin.Close()
+	if err != nil {
+		log.Fatalf("Failed to close sandbox stdin: %v", err)
+	}
+
+	output, err := io.ReadAll(sb.Stdout)
+	if err != nil {
+		log.Fatalf("Failed to read from sandbox stdout: %v", err)
+	}
+
+	log.Printf("output: %s\n", string(output))
+}

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -16,13 +16,14 @@ type Image struct {
 	ctx context.Context
 }
 
-func fromRegistryInternal(app *App, tag string) (*Image, error) {
+func fromRegistryInternal(app *App, tag string, imageRegistryConfig *pb.ImageRegistryConfig) (*Image, error) {
 	resp, err := client.ImageGetOrCreate(
 		app.ctx,
 		pb.ImageGetOrCreateRequest_builder{
 			AppId: app.AppId,
 			Image: pb.Image_builder{
-				DockerfileCommands: []string{`FROM ` + tag},
+				DockerfileCommands:  []string{`FROM ` + tag},
+				ImageRegistryConfig: imageRegistryConfig,
 			}.Build(),
 			Namespace:      pb.DeploymentNamespace_DEPLOYMENT_NAMESPACE_WORKSPACE,
 			BuilderVersion: "2024.10", // TODO: make this configurable

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -26,7 +26,7 @@ func fromRegistryInternal(app *App, tag string, imageRegistryConfig *pb.ImageReg
 				ImageRegistryConfig: imageRegistryConfig,
 			}.Build(),
 			Namespace:      pb.DeploymentNamespace_DEPLOYMENT_NAMESPACE_WORKSPACE,
-			BuilderVersion: "2024.10", // TODO: make this configurable
+			BuilderVersion: imageBuilderVersion(""),
 		}.Build(),
 	)
 	if err != nil {

--- a/modal-go/secret.go
+++ b/modal-go/secret.go
@@ -1,0 +1,43 @@
+package modal
+
+import (
+	"context"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+)
+
+// Secret represents a Modal secret.
+type Secret struct {
+	SecretId string
+
+	//lint:ignore U1000 may be used in future
+	ctx context.Context
+}
+
+// SecretFromNameOptions are options for finding Modal secrets.
+type SecretFromNameOptions struct {
+	Environment  string
+	RequiredKeys []string
+}
+
+// SecretFromName references a modal.Secret by its name.
+func SecretFromName(ctx context.Context, name string, options *SecretFromNameOptions) (*Secret, error) {
+	ctx = clientContext(ctx)
+
+	if options == nil {
+		options = &SecretFromNameOptions{}
+	}
+
+	resp, err := client.SecretGetOrCreate(ctx, pb.SecretGetOrCreateRequest_builder{
+		DeploymentName:  name,
+		Namespace:       pb.DeploymentNamespace_DEPLOYMENT_NAMESPACE_WORKSPACE,
+		EnvironmentName: environmentName(options.Environment),
+		RequiredKeys:    options.RequiredKeys,
+	}.Build())
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Secret{SecretId: resp.GetSecretId()}, nil
+}

--- a/modal-go/test/image_test.go
+++ b/modal-go/test/image_test.go
@@ -12,7 +12,7 @@ func TestImageFromRegistry(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	app, err := modal.AppLookup(context.Background(), "libmodal-test", modal.LookupOptions{CreateIfMissing: true})
+	app, err := modal.AppLookup(context.Background(), "libmodal-test", &modal.LookupOptions{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image, err := app.ImageFromRegistry("alpine:3.21")
@@ -24,7 +24,7 @@ func TestImageFromAwsEcr(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	app, err := modal.AppLookup(context.Background(), "libmodal-test", modal.LookupOptions{CreateIfMissing: true})
+	app, err := modal.AppLookup(context.Background(), "libmodal-test", &modal.LookupOptions{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	secret, err := modal.SecretFromName(context.Background(), "aws-ecr-private-registry-test-secret", &modal.SecretFromNameOptions{

--- a/modal-go/test/image_test.go
+++ b/modal-go/test/image_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modal-labs/libmodal/modal-go"
+	"github.com/onsi/gomega"
+)
+
+func TestImageFromRegistry(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	app, err := modal.AppLookup(context.Background(), "libmodal-test", modal.LookupOptions{CreateIfMissing: true})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	image, err := app.ImageFromRegistry("alpine:3.21")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(image.ImageId).Should(gomega.HavePrefix("im-"))
+}
+
+func TestImageFromAwsEcr(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	app, err := modal.AppLookup(context.Background(), "libmodal-test", modal.LookupOptions{CreateIfMissing: true})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	secret, err := modal.SecretFromName(context.Background(), "aws-ecr-private-registry-test-secret", &modal.SecretFromNameOptions{
+		Environment:  "libmodal",
+		RequiredKeys: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
+	})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	image, err := app.ImageFromAwsEcr("459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python", secret)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(image.ImageId).Should(gomega.HavePrefix("im-"))
+}

--- a/modal-go/test/secret_test.go
+++ b/modal-go/test/secret_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modal-labs/libmodal/modal-go"
+	"github.com/onsi/gomega"
+)
+
+func TestSecretFromName(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	secret, err := modal.SecretFromName(context.Background(), "test-secret", nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(secret.SecretId).Should(gomega.HavePrefix("st-"))
+
+	_, err = modal.SecretFromName(context.Background(), "missing-secret", nil)
+	g.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("Secret 'missing-secret' not found")))
+}
+
+func TestSecretFromNameWithEnvironment(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	secret, err := modal.SecretFromName(context.Background(), "test-secret", &modal.SecretFromNameOptions{
+		Environment: "libmodal",
+	})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(secret.SecretId).Should(gomega.HavePrefix("st-"))
+}
+
+func TestSecretFromNameWithRequiredKeys(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	secret, err := modal.SecretFromName(context.Background(), "test-secret", &modal.SecretFromNameOptions{
+		RequiredKeys: []string{"a", "b", "c"},
+	})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(secret.SecretId).Should(gomega.HavePrefix("st-"))
+
+	_, err = modal.SecretFromName(context.Background(), "test-secret", &modal.SecretFromNameOptions{
+		RequiredKeys: []string{"a", "b", "c", "missing-key"},
+	})
+	g.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("Secret is missing key(s): missing-key")))
+}

--- a/modal-js/eslint.config.js
+++ b/modal-js/eslint.config.js
@@ -16,6 +16,13 @@ export default defineConfig([
   },
   tseslint.configs.recommended,
   {
+    files: ["**/*.{ts,mts,cts}"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": [
@@ -31,6 +38,7 @@ export default defineConfig([
         },
       ],
       "@typescript-eslint/consistent-type-imports": "warn",
+      "@typescript-eslint/consistent-type-exports": "error",
     },
   },
 ]);

--- a/modal-js/eslint.config.js
+++ b/modal-js/eslint.config.js
@@ -30,6 +30,7 @@ export default defineConfig([
           ignoreRestSiblings: true,
         },
       ],
+      "@typescript-eslint/consistent-type-imports": "warn",
     },
   },
 ]);

--- a/modal-js/examples/sandbox-private-image.ts
+++ b/modal-js/examples/sandbox-private-image.ts
@@ -4,7 +4,6 @@ const app = await App.lookup("libmodal-example", { createIfMissing: true });
 const image = await app.imageFromAwsEcr(
   "459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python",
   await Secret.fromName("aws-ecr-private-registry-test-secret", {
-    environment: "libmodal",
     requiredKeys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
   }),
 );

--- a/modal-js/examples/sandbox-private-image.ts
+++ b/modal-js/examples/sandbox-private-image.ts
@@ -1,0 +1,26 @@
+import { App, Secret } from "modal";
+
+const app = await App.lookup("libmodal-example", { createIfMissing: true });
+const image = await app.imageFromAwsEcr(
+  "459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python",
+  await Secret.fromName("aws-ecr-private-registry-test-secret", {
+    environment: "libmodal",
+    requiredKeys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+  }),
+);
+
+// Spawn a sandbox running a simple Python version of the "cat" command.
+const sb = await app.createSandbox(image, {
+  command: ["python", "-c", `import sys; sys.stdout.write(sys.stdin.read())`],
+});
+console.log("sandbox:", sb.sandboxId);
+
+// Write to the sandbox's stdin and read from its stdout.
+await sb.stdin.writeText(
+  "this is input that should be mirrored by the Python one-liner",
+);
+await sb.stdin.close();
+console.log("output:", await sb.stdout.readText());
+
+// Terminate the sandbox.
+await sb.terminate();

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -27,7 +27,7 @@
     "docs:serve": "npm run docs && http-server ./docs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "eslint",
+    "lint": "eslint --ignore-pattern 'docs/*'",
     "prepare": "scripts/gen-proto.sh",
     "test": "vitest"
   },

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -27,7 +27,7 @@
     "docs:serve": "npm run docs && http-server ./docs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "eslint --ignore-pattern 'docs/*'",
+    "lint": "eslint",
     "prepare": "scripts/gen-proto.sh",
     "test": "vitest"
   },

--- a/modal-js/src/app.ts
+++ b/modal-js/src/app.ts
@@ -6,7 +6,8 @@ import {
 } from "../proto/modal_proto/api";
 import { client } from "./client";
 import { environmentName } from "./config";
-import { fromRegistryInternal, Image } from "./image";
+import type { Image } from "./image";
+import { fromRegistryInternal } from "./image";
 import { Sandbox } from "./sandbox";
 import { NotFoundError } from "./errors";
 import { Secret } from "./secret";

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -1,9 +1,11 @@
 import { v4 as uuidv4 } from "uuid";
-import {
+import type {
   CallOptions,
-  ClientError,
   ClientMiddleware,
   ClientMiddlewareCall,
+} from "nice-grpc";
+import {
+  ClientError,
   createChannel,
   createClientFactory,
   Metadata,
@@ -11,7 +13,8 @@ import {
 } from "nice-grpc";
 
 import { ClientType, ModalClientDefinition } from "../proto/modal_proto/api";
-import { profile, Profile } from "./config";
+import type { Profile } from "./config";
+import { profile } from "./config";
 
 /** gRPC client middleware to add auth token to request. */
 function authMiddleware(profile: Profile): ClientMiddleware {

--- a/modal-js/src/cls.ts
+++ b/modal-js/src/cls.ts
@@ -1,13 +1,15 @@
 import { ClientError, Status } from "nice-grpc";
+import type {
+  ClassParameterSpec,
+  ClassParameterValue,
+} from "../proto/modal_proto/api";
 import {
   ClassParameterInfo_ParameterSerializationFormat,
   ClassParameterSet,
-  ClassParameterSpec,
-  ClassParameterValue,
   DeploymentNamespace,
   ParameterType,
 } from "../proto/modal_proto/api";
-import { LookupOptions } from "./app";
+import type { LookupOptions } from "./app";
 import { NotFoundError } from "./errors";
 import { client } from "./client";
 import { environmentName } from "./config";

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -10,6 +10,7 @@ interface Config {
     token_id?: string;
     token_secret?: string;
     environment?: string;
+    imageBuilderVersion?: string;
     active?: boolean;
   };
 }
@@ -20,6 +21,7 @@ export interface Profile {
   tokenId: string;
   tokenSecret: string;
   environment?: string;
+  imageBuilderVersion?: string;
 }
 
 async function readConfigFile(): Promise<Config> {
@@ -64,6 +66,9 @@ export function getProfile(profileName?: string): Profile {
     tokenId: process.env["MODAL_TOKEN_ID"] || profileData.token_id,
     tokenSecret: process.env["MODAL_TOKEN_SECRET"] || profileData.token_secret,
     environment: process.env["MODAL_ENVIRONMENT"] || profileData.environment,
+    imageBuilderVersion:
+      process.env["MODAL_IMAGE_BUILDER_VERSION"] ||
+      profileData.imageBuilderVersion,
   };
   if (!profile.tokenId || !profile.tokenSecret) {
     throw new Error(
@@ -80,5 +85,5 @@ export function environmentName(environment?: string): string {
 }
 
 export function imageBuilderVersion(version?: string): string {
-  return version || process.env.MODAL_IMAGE_BUILDER_VERSION || "2024.10";
+  return version || profile.imageBuilderVersion || "2024.10";
 }

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -78,3 +78,7 @@ export const profile = getProfile(process.env["MODAL_PROFILE"] || undefined);
 export function environmentName(environment?: string): string {
   return environment || profile.environment || "";
 }
+
+export function imageBuilderVersion(version?: string): string {
+  return version || process.env.MODAL_IMAGE_BUILDER_VERSION || "2024.10";
+}

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -2,17 +2,19 @@
 
 import { createHash } from "node:crypto";
 
+import type {
+  FunctionGetOutputsResponse,
+  GenericResult,
+} from "../proto/modal_proto/api";
 import {
   DataFormat,
   DeploymentNamespace,
   FunctionCallInvocationType,
   FunctionCallType,
-  FunctionGetOutputsResponse,
   GeneratorDone,
-  GenericResult,
   GenericResult_GenericStatus,
 } from "../proto/modal_proto/api";
-import { LookupOptions } from "./app";
+import type { LookupOptions } from "./app";
 import { client } from "./client";
 import { FunctionCall } from "./function_call";
 import { environmentName } from "./config";

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -5,6 +5,7 @@ import {
   ImageMetadata,
 } from "../proto/modal_proto/api";
 import { client } from "./client";
+import { imageBuilderVersion } from "./config";
 
 /** A container image, used for starting sandboxes. */
 export class Image {
@@ -26,7 +27,7 @@ export async function fromRegistryInternal(
       dockerfileCommands: [`FROM ${tag}`],
     },
     namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
-    builderVersion: "2024.10", // TODO: make this configurable
+    builderVersion: imageBuilderVersion(),
   });
 
   let result: GenericResult;

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -3,6 +3,7 @@ import {
   GenericResult,
   GenericResult_GenericStatus,
   ImageMetadata,
+  ImageRegistryConfig,
 } from "../proto/modal_proto/api";
 import { client } from "./client";
 import { imageBuilderVersion } from "./config";
@@ -20,11 +21,13 @@ export class Image {
 export async function fromRegistryInternal(
   appId: string,
   tag: string,
+  imageRegistryConfig?: ImageRegistryConfig,
 ): Promise<Image> {
   const resp = await client.imageGetOrCreate({
     appId,
     image: {
       dockerfileCommands: [`FROM ${tag}`],
+      imageRegistryConfig: imageRegistryConfig,
     },
     namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
     builderVersion: imageBuilderVersion(),
@@ -84,6 +87,5 @@ export async function fromRegistryInternal(
       `Image build for ${resp.imageId} failed with unknown status: ${result.status}`,
     );
   }
-
   return new Image(resp.imageId);
 }

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -1,9 +1,11 @@
-import {
-  DeploymentNamespace,
+import type {
   GenericResult,
-  GenericResult_GenericStatus,
   ImageMetadata,
   ImageRegistryConfig,
+} from "../proto/modal_proto/api";
+import {
+  DeploymentNamespace,
+  GenericResult_GenericStatus,
 } from "../proto/modal_proto/api";
 import { client } from "./client";
 import { imageBuilderVersion } from "./config";

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -30,12 +30,7 @@ export {
   type QueuePutOptions,
 } from "./queue";
 export { Image } from "./image";
-export {
-  ContainerProcess,
-  ExecOptions,
-  Sandbox,
-  type StdioBehavior,
-  type StreamMode,
-} from "./sandbox";
-export { ModalReadStream, ModalWriteStream } from "./streams";
+export type { ExecOptions, StdioBehavior, StreamMode } from "./sandbox";
+export { ContainerProcess, Sandbox } from "./sandbox";
+export type { ModalReadStream, ModalWriteStream } from "./streams";
 export { Secret, type SecretFromNameOptions } from "./secret";

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -38,3 +38,4 @@ export {
   type StreamMode,
 } from "./sandbox";
 export { ModalReadStream, ModalWriteStream } from "./streams";
+export { Secret, type SecretFromNameOptions } from "./secret";

--- a/modal-js/src/pickle.test.ts
+++ b/modal-js/src/pickle.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
-import { dumps, loads, Protocol } from "./pickle";
+import type { Protocol } from "./pickle";
+import { dumps, loads } from "./pickle";
 
 test("PickleUnpickle", () => {
   const sample = {

--- a/modal-js/src/queue.ts
+++ b/modal-js/src/queue.ts
@@ -1,16 +1,16 @@
 // Queue object, to be used with Modal Queues.
 
+import type { QueueNextItemsRequest } from "../proto/modal_proto/api";
 import {
   DeploymentNamespace,
   ObjectCreationType,
-  QueueNextItemsRequest,
 } from "../proto/modal_proto/api";
 import { client } from "./client";
 import { environmentName } from "./config";
 import { InvalidError, QueueEmptyError, QueueFullError } from "./errors";
 import { dumps, loads } from "./pickle";
 import { ClientError, Status } from "nice-grpc";
-import { DeleteOptions, EphemeralOptions, LookupOptions } from "./app";
+import type { DeleteOptions, EphemeralOptions, LookupOptions } from "./app";
 
 // From: modal/_object.py
 const ephemeralObjectHeartbeatSleep = 300_000; // 300 seconds

--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -1,8 +1,7 @@
 import { FileDescriptor } from "../proto/modal_proto/api";
 import { client, isRetryableGrpc } from "./client";
+import type { ModalReadStream, ModalWriteStream } from "./streams";
 import {
-  ModalReadStream,
-  ModalWriteStream,
   streamConsumingIter,
   toModalReadStream,
   toModalWriteStream,

--- a/modal-js/src/secret.ts
+++ b/modal-js/src/secret.ts
@@ -1,0 +1,47 @@
+import { DeploymentNamespace } from "../proto/modal_proto/api";
+import { client } from "./client";
+import { environmentName as configEnvironmentName } from "./config";
+import { ClientError, Status } from "nice-grpc";
+import { NotFoundError } from "./errors";
+
+/** Options for `Secret.fromName()`. */
+export type SecretFromNameOptions = {
+  environment?: string;
+  requiredKeys?: string[];
+};
+
+/** Secrets provide a dictionary of environment variables for images. */
+export class Secret {
+  readonly secretId: string;
+
+  /** @ignore */
+  constructor(secretId: string) {
+    this.secretId = secretId;
+  }
+
+  /** Reference a Secret by its name. */
+  static async fromName(
+    name: string,
+    options?: SecretFromNameOptions,
+  ): Promise<Secret> {
+    try {
+      const resp = await client.secretGetOrCreate({
+        deploymentName: name,
+        namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environmentName: configEnvironmentName(options?.environment),
+        requiredKeys: options?.requiredKeys ?? [],
+      });
+      return new Secret(resp.secretId);
+    } catch (err) {
+      if (err instanceof ClientError && err.code === Status.NOT_FOUND)
+        throw new NotFoundError(err.details);
+      if (
+        err instanceof ClientError &&
+        err.code === Status.FAILED_PRECONDITION &&
+        err.details.includes("Secret is missing key")
+      )
+        throw new NotFoundError(err.details);
+      throw err;
+    }
+  }
+}

--- a/modal-js/test/image.test.ts
+++ b/modal-js/test/image.test.ts
@@ -1,0 +1,26 @@
+import { App, Secret } from "modal";
+import { expect, test } from "vitest";
+
+test("ImageFromRegistry", { timeout: 30_000 }, async () => {
+  const app = await App.lookup("libmodal-test", { createIfMissing: true });
+  expect(app.appId).toBeTruthy();
+
+  const image = await app.imageFromRegistry("alpine:3.21");
+  expect(image.imageId).toBeTruthy();
+  expect(image.imageId).toMatch(/^im-/);
+});
+
+test("ImageFromAwsEcr", { timeout: 30_000 }, async () => {
+  const app = await App.lookup("libmodal-test", { createIfMissing: true });
+  expect(app.appId).toBeTruthy();
+
+  const image = await app.imageFromAwsEcr(
+    "459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python",
+    await Secret.fromName("aws-ecr-private-registry-test-secret", {
+      environment: "libmodal",
+      requiredKeys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+    }),
+  );
+  expect(image.imageId).toBeTruthy();
+  expect(image.imageId).toMatch(/^im-/);
+});

--- a/modal-js/test/secret.test.ts
+++ b/modal-js/test/secret.test.ts
@@ -1,0 +1,35 @@
+import { Secret } from "modal";
+import { expect, test } from "vitest";
+
+test("SecretFromName", async () => {
+  const secret = await Secret.fromName("test-secret");
+  expect(secret).toBeDefined();
+  expect(secret.secretId).toBeDefined();
+  expect(secret.secretId).toMatch(/^st-/);
+
+  const promise = Secret.fromName("missing-secret");
+  await expect(promise).rejects.toThrowError(
+    /Secret 'missing-secret' not found/,
+  );
+});
+
+test("SecretFromNameWithEnvironment", async () => {
+  const secret = await Secret.fromName("test-secret", {
+    environment: "libmodal",
+  });
+  expect(secret).toBeDefined();
+});
+
+test("SecretFromNameWithRequiredKeys", async () => {
+  const secret = await Secret.fromName("test-secret", {
+    requiredKeys: ["a", "b", "c"],
+  });
+  expect(secret).toBeDefined();
+
+  const promise = Secret.fromName("test-secret", {
+    requiredKeys: ["a", "b", "c", "missing-key"],
+  });
+  await expect(promise).rejects.toThrowError(
+    /Secret is missing key\(s\): missing-key/,
+  );
+});

--- a/modal-js/tsconfig.json
+++ b/modal-js/tsconfig.json
@@ -13,12 +13,5 @@
       "modal": ["./src/index.ts"]
     }
   },
-  "include": [
-    "src",
-    "examples",
-    "test",
-    "*.config.ts",
-    "vitest.config.ts",
-    "tsup.config.ts"
-  ]
+  "include": ["src", "examples", "test", "*.config.ts"]
 }

--- a/modal-js/tsconfig.json
+++ b/modal-js/tsconfig.json
@@ -13,5 +13,12 @@
       "modal": ["./src/index.ts"]
     }
   },
-  "include": ["src", "examples"]
+  "include": [
+    "src",
+    "examples",
+    "test",
+    "*.config.ts",
+    "vitest.config.ts",
+    "tsup.config.ts"
+  ]
 }


### PR DESCRIPTION
CLI-433

Adds support similar to [modal.Image.from_aws_ecr()](https://modal.com/docs/reference/modal.Image#from_aws_ecr), related support for `Secret`s.