### PR TITLE
Follow-ups to #12 Function.spawn in Go and TS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm install modal
 Examples:
 
 - [Call a deployed function](./modal-js/examples/function-call.ts)
+- [Spawn a deployed function](./modal-js/examples/function-spawn.ts)
 - [Call a deployed cls](./modal-js/examples/cls-call.ts)
 - [Create a sandbox](./modal-js/examples/sandbox.ts)
 - [Execute sandbox commands](./modal-js/examples/sandbox-exec.ts)

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -195,7 +195,7 @@ func encodeParameter(paramSpec *pb.ClassParameterSpec, value any) (*pb.ClassPara
 		paramValue.SetBytesValue(bytesValue)
 
 	default:
-		return nil, fmt.Errorf("unsupported parameter type: %w", paramType)
+		return nil, fmt.Errorf("unsupported parameter type: %v", paramType)
 	}
 
 	return paramValue, nil

--- a/modal-go/examples/cls-call/main.go
+++ b/modal-go/examples/cls-call/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/modal-labs/libmodal/modal-go"
@@ -19,30 +18,30 @@ func main() {
 		"libmodal-test-support", "EchoCls", modal.LookupOptions{},
 	)
 	if err != nil {
-		fmt.Errorf("Failed to lookup Cls: %w", err)
+		log.Fatalf("Failed to lookup Cls: %v", err)
 	}
 
 	instance, err := cls.Instance(nil)
 	if err != nil {
-		fmt.Errorf("Failed to create Cls instance: %w", err)
+		log.Fatalf("Failed to create Cls instance: %v", err)
 	}
 
 	function, err := instance.Method("echo_string")
 	if err != nil {
-		fmt.Errorf("Failed to access Cls method: %w", err)
+		log.Fatalf("Failed to access Cls method: %v", err)
 	}
 
 	// Call the Cls function with args.
 	result, err := function.Remote([]any{"Hello world!"}, nil)
 	if err != nil {
-		fmt.Errorf("Failed to call Cls method: %w", err)
+		log.Fatalf("Failed to call Cls method: %v", err)
 	}
 	log.Println("Response:", result)
 
 	// Call the Cls function with kwargs.
 	result, err = function.Remote(nil, map[string]any{"s": "Hello world!"})
 	if err != nil {
-		fmt.Errorf("Failed to call Cls method: %w", err)
+		log.Fatalf("Failed to call Cls method: %v", err)
 	}
 	log.Println("Response:", result)
 }

--- a/modal-go/examples/function-call/main.go
+++ b/modal-go/examples/function-call/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/modal-labs/libmodal/modal-go"
@@ -15,18 +14,18 @@ func main() {
 
 	echo, err := modal.FunctionLookup(ctx, "libmodal-test-support", "echo_string", modal.LookupOptions{})
 	if err != nil {
-		fmt.Errorf("Failed to lookup function: %w", err)
+		log.Fatalf("Failed to lookup function: %v", err)
 	}
 
 	ret, err := echo.Remote([]any{"Hello world!"}, nil)
 	if err != nil {
-		fmt.Errorf("Failed to call function: %w", err)
+		log.Fatalf("Failed to call function: %v", err)
 	}
 	log.Println("Response:", ret)
 
 	ret, err = echo.Remote(nil, map[string]any{"s": "Hello world!"})
 	if err != nil {
-		fmt.Errorf("Failed to call function with kwargs: %w", err)
+		log.Fatalf("Failed to call function with kwargs: %v", err)
 	}
 	log.Println("Response:", ret)
 }

--- a/modal-go/examples/function-spawn/main.go
+++ b/modal-go/examples/function-spawn/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/modal-labs/libmodal/modal-go"
@@ -16,17 +15,17 @@ func main() {
 
 	echo, err := modal.FunctionLookup(ctx, "libmodal-test-support", "echo_string", modal.LookupOptions{})
 	if err != nil {
-		fmt.Errorf("Failed to lookup function: %w", err)
+		log.Fatalf("Failed to lookup function: %v", err)
 	}
 
 	fc, err := echo.Spawn(nil, map[string]any{"s": "Hello world!"})
 	if err != nil {
-		fmt.Errorf("Failed to spawn function: %w", err)
+		log.Fatalf("Failed to spawn function: %v", err)
 	}
 
 	ret, err := fc.Get(modal.FunctionCallGetOptions{})
 	if err != nil {
-		fmt.Errorf("Failed to get function results: %w", err)
+		log.Fatalf("Failed to get function results: %v", err)
 	}
 	log.Println("Response:", ret)
 }

--- a/modal-go/examples/sandbox-exec/main.go
+++ b/modal-go/examples/sandbox-exec/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 
@@ -14,17 +13,17 @@ func main() {
 
 	app, err := modal.AppLookup(ctx, "libmodal-example", modal.LookupOptions{CreateIfMissing: true})
 	if err != nil {
-		fmt.Errorf("Failed to lookup or create app: %w", err)
+		log.Fatalf("Failed to lookup or create app: %v", err)
 	}
 
 	image, err := app.ImageFromRegistry("python:3.13-slim")
 	if err != nil {
-		fmt.Errorf("Failed to create image from registry: %w", err)
+		log.Fatalf("Failed to create image from registry: %v", err)
 	}
 
 	sb, err := app.CreateSandbox(image, modal.SandboxOptions{})
 	if err != nil {
-		fmt.Errorf("Failed to create sandbox: %w", err)
+		log.Fatalf("Failed to create sandbox: %v", err)
 	}
 	log.Println("Started sandbox:", sb.SandboxId)
 	defer sb.Terminate()
@@ -48,22 +47,22 @@ for i in range(50000):
 		},
 	)
 	if err != nil {
-		fmt.Errorf("Failed to execute command in sandbox: %w", err)
+		log.Fatalf("Failed to execute command in sandbox: %v", err)
 	}
 
 	contentStdout, err := io.ReadAll(p.Stdout)
 	if err != nil {
-		fmt.Errorf("Failed to read stdout: %w", err)
+		log.Fatalf("Failed to read stdout: %v", err)
 	}
 	contentStderr, err := io.ReadAll(p.Stderr)
 	if err != nil {
-		fmt.Errorf("Failed to read stderr: %w", err)
+		log.Fatalf("Failed to read stderr: %v", err)
 	}
 
 	log.Printf("Got %d bytes stdout and %d bytes stderr\n", len(contentStdout), len(contentStderr))
 	returnCode, err := p.Wait()
 	if err != nil {
-		fmt.Errorf("Failed to wait for process completion: %w", err)
+		log.Fatalf("Failed to wait for process completion: %v", err)
 	}
 	log.Println("Return code:", returnCode)
 

--- a/modal-go/examples/sandbox/main.go
+++ b/modal-go/examples/sandbox/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 
@@ -14,34 +13,34 @@ func main() {
 
 	app, err := modal.AppLookup(ctx, "libmodal-example", modal.LookupOptions{CreateIfMissing: true})
 	if err != nil {
-		fmt.Errorf("Failed to lookup or create app: %w", err)
+		log.Fatalf("Failed to lookup or create app: %v", err)
 	}
 
 	image, err := app.ImageFromRegistry("alpine:3.21")
 	if err != nil {
-		fmt.Errorf("Failed to create image from registry: %w", err)
+		log.Fatalf("Failed to create image from registry: %v", err)
 	}
 
 	sb, err := app.CreateSandbox(image, modal.SandboxOptions{
 		Command: []string{"cat"},
 	})
 	if err != nil {
-		fmt.Errorf("Failed to create sandbox: %w", err)
+		log.Fatalf("Failed to create sandbox: %v", err)
 	}
 	log.Printf("sandbox: %s\n", sb.SandboxId)
 
 	_, err = sb.Stdin.Write([]byte("this is input that should be mirrored by cat"))
 	if err != nil {
-		fmt.Errorf("Failed to write to sandbox stdin: %w", err)
+		log.Fatalf("Failed to write to sandbox stdin: %v", err)
 	}
 	err = sb.Stdin.Close()
 	if err != nil {
-		fmt.Errorf("Failed to close sandbox stdin: %w", err)
+		log.Fatalf("Failed to close sandbox stdin: %v", err)
 	}
 
 	output, err := io.ReadAll(sb.Stdout)
 	if err != nil {
-		fmt.Errorf("Failed to read from sandbox stdout: %w", err)
+		log.Fatalf("Failed to read from sandbox stdout: %v", err)
 	}
 
 	log.Printf("output: %s\n", string(output))

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -16,7 +16,7 @@ type FunctionCall struct {
 	ctx            context.Context
 }
 
-// FunctionCallFromId looks up a FunctionCall.
+// FunctionCallFromId looks up a FunctionCall by ID.
 func FunctionCallFromId(ctx context.Context, functionCallId string) (*FunctionCall, error) {
 	ctx = clientContext(ctx)
 	functionCall := FunctionCall{
@@ -28,28 +28,17 @@ func FunctionCallFromId(ctx context.Context, functionCallId string) (*FunctionCa
 
 // FunctionCallGetOptions are options for getting outputs from Function Calls.
 type FunctionCallGetOptions struct {
-	Timeout time.Duration
+	// Timeout specifies the maximum duration to wait for the output.
+	// If nil, no timeout is applied. If set to 0, it will check if the function
+	// call is already completed.
+	Timeout *time.Duration
 }
 
 // Get waits for the output of a FunctionCall.
 // If timeout > 0, the operation will be cancelled after the specified duration.
 func (fc *FunctionCall) Get(options FunctionCallGetOptions) (any, error) {
 	ctx := fc.ctx
-
-	// Use default if not specified.
-	timeoutSeconds := options.Timeout
-	if options.Timeout == 0 {
-		timeoutSeconds = OutputsTimeout
-	}
-	return pollFunctionOutput(ctx, fc.FunctionCallId, timeoutSeconds)
-}
-
-// Helper function to find the minimum of two float32 values
-func minTimeout(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
+	return pollFunctionOutput(ctx, fc.FunctionCallId, options.Timeout)
 }
 
 // FunctionCallCancelOptions are options for cancelling Function Calls.

--- a/modal-go/test/function_call_test.go
+++ b/modal-go/test/function_call_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	pickle "github.com/kisielk/og-rek"
 	"github.com/modal-labs/libmodal/modal-go"
 	"github.com/onsi/gomega"
 )
@@ -37,13 +38,13 @@ func TestFunctionSpawn(t *testing.T) {
 	g.Expect(result).Should(gomega.Equal("output: hello"))
 
 	// Looking function that takes a long time to complete.
-	functionSleep, err := modal.FunctionLookup(
+	sleep, err := modal.FunctionLookup(
 		context.Background(),
 		"libmodal-test-support", "sleep", modal.LookupOptions{},
 	)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	functionCall, err = functionSleep.Spawn(nil, map[string]any{"t": 5})
+	functionCall, err = sleep.Spawn(nil, map[string]any{"t": 5})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	// Cancel function call.
@@ -56,10 +57,40 @@ func TestFunctionSpawn(t *testing.T) {
 	g.Expect(err).Should(gomega.HaveOccurred())
 
 	// Spawn function with long running input.
-	functionCall, err = functionSleep.Spawn(nil, map[string]any{"t": 5})
+	functionCall, err = sleep.Spawn(nil, map[string]any{"t": 5})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	// Get is now expected to timeout.
-	_, err = functionCall.Get(modal.FunctionCallGetOptions{Timeout: 1 * time.Second})
+	timeout := 1 * time.Second
+	_, err = functionCall.Get(modal.FunctionCallGetOptions{Timeout: &timeout})
 	g.Expect(err).Should(gomega.HaveOccurred())
+}
+
+func TestFunctionCallGet0(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	sleep, _ := modal.FunctionLookup(
+		context.Background(),
+		"libmodal-test-support", "sleep", modal.LookupOptions{},
+	)
+
+	functionCall, err := sleep.Spawn([]any{0.5}, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	// Polling for output with timeout 0 should raise an error, since the
+	// function call has not finished yet.
+	timeout := 0 * time.Second
+	_, err = functionCall.Get(modal.FunctionCallGetOptions{Timeout: &timeout})
+	g.Expect(err).Should(gomega.HaveOccurred())
+
+	// Wait for the function call to finish.
+	result, err := functionCall.Get(modal.FunctionCallGetOptions{})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal(pickle.None{}))
+
+	// Now we can get the result.
+	result, err = functionCall.Get(modal.FunctionCallGetOptions{Timeout: &timeout})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).Should(gomega.Equal(pickle.None{}))
 }

--- a/modal-go/test/sandbox_test.go
+++ b/modal-go/test/sandbox_test.go
@@ -24,6 +24,10 @@ func TestCreateOneSandbox(t *testing.T) {
 
 	err = sb.Terminate()
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	exitcode, err := sb.Wait()
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(exitcode).To(gomega.Equal(int32(0)))
 }
 
 func TestPassCatToStdin(t *testing.T) {

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -26,7 +26,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "scripts/gen-proto.sh",
-    "test": "vitest --reporter=verbose"
+    "test": "vitest"
   },
   "dependencies": {
     "long": "^5.3.1",

--- a/modal-js/src/function_call.ts
+++ b/modal-js/src/function_call.ts
@@ -1,7 +1,7 @@
 // Manage existing Function Calls (look-ups, polling for output, cancellation).
 
 import { client } from "./client";
-import { pollFunctionOutput, outputsTimeout } from "./function";
+import { pollFunctionOutput } from "./function";
 
 export type FunctionCallGetOptions = {
   timeout?: number; // in milliseconds
@@ -11,10 +11,11 @@ export type FunctionCallCancelOptions = {
   terminateContainers?: boolean;
 };
 
-/** Represents a Modal FunctionCall, Function Calls are
-Function invocations with a given input. They can be consumed
-asynchronously (see get()) or cancelled (see cancel()).
-*/
+/**
+ * Represents a Modal FunctionCall. Function Calls are Function invocations with
+ * a given input. They can be consumed asynchronously (see `get()`) or cancelled
+ * (see `cancel()`).
+ */
 export class FunctionCall {
   readonly functionCallId: string;
 
@@ -22,24 +23,22 @@ export class FunctionCall {
     this.functionCallId = functionCallId;
   }
 
-  // Get output for a FunctionCall ID.
+  /** Create a new function call from ID. */
+  fromId(functionCallId: string): FunctionCall {
+    return new FunctionCall(functionCallId);
+  }
+
+  /** Get the result of a function call, optionally waiting with a timeout. */
   async get(options: FunctionCallGetOptions = {}): Promise<any> {
-    const timeout = options.timeout || outputsTimeout;
+    const timeout = options.timeout;
     return await pollFunctionOutput(this.functionCallId, timeout);
   }
 
-  // Cancel ongoing FunctionCall.
+  /** Cancel a running function call. */
   async cancel(options: FunctionCallCancelOptions = {}) {
     await client.functionCallCancel({
       functionCallId: this.functionCallId,
       terminateContainers: options.terminateContainers,
     });
   }
-}
-
-// functionCallFromId looks up a FunctionCall.
-export async function functionCallFromId(
-  functionCallId: string,
-): Promise<FunctionCall> {
-  return new FunctionCall(functionCallId);
 }

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -7,5 +7,10 @@ export {
   NotFoundError,
 } from "./errors";
 export { Function_ } from "./function";
+export {
+  FunctionCall,
+  type FunctionCallGetOptions,
+  type FunctionCallCancelOptions,
+} from "./function_call";
 export { Image } from "./image";
 export { Sandbox, type StdioBehavior, type StreamMode } from "./sandbox";

--- a/modal-js/test/function_call.test.ts
+++ b/modal-js/test/function_call.test.ts
@@ -20,16 +20,27 @@ test("FunctionSpawn", async () => {
   expect(resultKwargs).toBe("output: hello");
 
   // Lookup function that takes a long time to complete.
-  const functionSleep_ = await Function_.lookup(
-    "libmodal-test-support",
-    "sleep",
-  );
+  const sleep = await Function_.lookup("libmodal-test-support", "sleep");
 
   // Spawn with long running input.
-  functionCall = await functionSleep_.spawn([], { t: 5 });
+  functionCall = await sleep.spawn([], { t: 5 });
   expect(functionCall.functionCallId).toBeDefined();
 
   // Getting outputs with timeout raises error.
   const promise = functionCall.get({ timeout: 1000 }); // 1000ms
   await expect(promise).rejects.toThrowError(FunctionTimeoutError);
+});
+
+test("FunctionCallGet0", async () => {
+  const sleep = await Function_.lookup("libmodal-test-support", "sleep");
+
+  const call = await sleep.spawn([0.5]);
+  // Polling for output with timeout 0 should raise an error, since the
+  // function call has not finished yet.
+  await expect(call.get({ timeout: 0 })).rejects.toThrowError(
+    FunctionTimeoutError,
+  );
+
+  expect(await call.get()).toBe(null); // Wait for the function call to finish.
+  expect(await call.get({ timeout: 0 })).toBe(null); // Now we can get the result.
 });

--- a/modal-js/vitest.config.ts
+++ b/modal-js/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     maxConcurrency: 10,
     slowTestThreshold: 5_000,
     testTimeout: 20_000,
+    reporters: ["verbose"],
   },
 });

--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -9,9 +9,11 @@ app = modal.App("libmodal-test-support")
 def echo_string(s: str) -> str:
     return "output: " + s
 
+
 @app.function(min_containers=1)
 def sleep(t: int) -> None:
     time.sleep(t)
+
 
 @app.function(min_containers=1)
 def bytelength(buf: bytes) -> int:


### PR DESCRIPTION
Some follow-ups here, the main behavior change was that:

- `timeout` should be undefined by default rather than `55`, which waits indefinitely.
- `timeout` when set to 0 should poll once with an immediate timeout, not wait for `55` seconds.

Added tests for this. Also edited the Go examples with the feedback about `%v` vs `%w`, I can install a linter so we don't need to manually follow-up with things like this.

