### PR TITLE
Implement Queue support for Go

### DIFF
--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -22,6 +22,16 @@ type LookupOptions struct {
 	CreateIfMissing bool
 }
 
+// DeleteOptions are options for deleting a named object.
+type DeleteOptions struct {
+	Environment string // Environment to delete the object from.
+}
+
+// EphemeralOptions are options for creating a temporary, nameless object.
+type EphemeralOptions struct {
+	Environment string // Environment to create the object in.
+}
+
 // SandboxOptions are options for creating a Modal Sandbox.
 type SandboxOptions struct {
 	CPU     float64       // CPU request in physical cores.

--- a/modal-go/errors.go
+++ b/modal-go/errors.go
@@ -37,3 +37,30 @@ type NotFoundError struct {
 func (e NotFoundError) Error() string {
 	return "NotFoundError: " + e.Exception
 }
+
+// InvalidError represents an invalid request or operation.
+type InvalidError struct {
+	Exception string
+}
+
+func (e InvalidError) Error() string {
+	return "InvalidError: " + e.Exception
+}
+
+// QueueEmptyError is returned when an operation is attempted on an empty queue.
+type QueueEmptyError struct {
+	Exception string
+}
+
+func (e QueueEmptyError) Error() string {
+	return "QueueEmptyError: " + e.Exception
+}
+
+// QueueFullError is returned when an operation is attempted on a full queue.
+type QueueFullError struct {
+	Exception string
+}
+
+func (e QueueFullError) Error() string {
+	return "QueueFullError: " + e.Exception
+}

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -61,15 +61,12 @@ func FunctionLookup(ctx context.Context, appName string, name string, options *L
 	return &Function{FunctionId: resp.GetFunctionId(), ctx: ctx}, nil
 }
 
-// Serialize function inputs to the Python pickle format.
-func pickleSerialize(args []any, kwargs map[string]any) (bytes.Buffer, error) {
+// Serialize Go data types to the Python pickle format.
+func pickleSerialize(v any) (bytes.Buffer, error) {
 	var inputBuffer bytes.Buffer
 
 	e := pickle.NewEncoder(&inputBuffer)
-	err := e.Encode(pickle.Tuple{
-		args,
-		kwargs,
-	})
+	err := e.Encode(v)
 
 	if err != nil {
 		return bytes.Buffer{}, fmt.Errorf("error pickling data: %w", err)
@@ -89,7 +86,7 @@ func pickleDeserialize(buffer []byte) (any, error) {
 
 // Serializes inputs, make a function call and return its ID
 func (f *Function) execFunctionCall(args []any, kwargs map[string]any, invocationType pb.FunctionCallInvocationType) (*string, error) {
-	payload, err := pickleSerialize(args, kwargs)
+	payload, err := pickleSerialize(pickle.Tuple{args, kwargs})
 	if err != nil {
 		return nil, err
 	}

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -56,6 +56,7 @@ type QueueIterateOptions struct {
 	Partition       string
 }
 
+// Queue is a distributed, FIFO queue for data flow in Modal apps.
 type Queue struct {
 	QueueId   string
 	cancel    context.CancelFunc // only for ephemeral queues

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -98,12 +98,13 @@ func QueueEphemeral(ctx context.Context, options *EphemeralOptions) (*Queue, err
 }
 
 // CloseEphemeral deletes an ephemeral queue, only used with QueueEphemeral.
-func (q *Queue) CloseEphemeral() error {
+func (q *Queue) CloseEphemeral() {
 	if q.ephemeral {
 		q.cancel() // will stop heartbeat
-		return nil
 	} else {
-		return InvalidError{fmt.Sprintf("queue %s is not ephemeral", q.QueueId)}
+		// We panic in this case because of invalid usage. In general, methods
+		// used with `defer` like CloseEphemeral should not return errors.
+		panic(fmt.Sprintf("queue %s is not ephemeral", q.QueueId))
 	}
 }
 

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -335,7 +335,7 @@ func (q *Queue) Len(options *QueueLenOptions) (int, error) {
 	return int(resp.GetLen()), nil
 }
 
-// Iterate yields items without mutating the queue.
+// Iterate yields items from the queue until it is empty.
 func (q *Queue) Iterate(options *QueueIterateOptions) iter.Seq2[any, error] {
 	if options == nil {
 		options = &QueueIterateOptions{}

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -1,0 +1,391 @@
+package modal
+
+// Queue object, to be used with Modal Queues.
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"time"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// From: modal/_object.py
+const ephemeralObjectHeartbeatSleep = 300 * time.Second
+
+func validatePartitionKey(partition string) ([]byte, error) {
+	if partition == "" {
+		return nil, nil // default partition
+	}
+	b := []byte(partition)
+	if len(b) == 0 || len(b) > 64 {
+		return nil, InvalidError{"queue partition key must be 1–64 bytes long"}
+	}
+	return b, nil
+}
+
+type QueueClearOptions struct {
+	Partition string // partition to clear (default "")
+	All       bool   // clear *all* partitions (mutually exclusive with Partition)
+}
+
+type QueueGetOptions struct {
+	Timeout   *time.Duration // wait max (nil = indefinitely)
+	Partition string
+}
+
+type QueuePutOptions struct {
+	Timeout      *time.Duration // max wait for space (nil = indefinitely)
+	Partition    string
+	PartitionTTL time.Duration // ttl for the *partition* (default 24h)
+}
+
+type QueueLenOptions struct {
+	Partition string
+	Total     bool // total across all partitions (mutually exclusive with Partition)
+}
+
+type QueueIterateOptions struct {
+	ItemPollTimeout time.Duration // exit if no new items within this period
+	Partition       string
+}
+
+type Queue struct {
+	QueueId   string
+	cancel    context.CancelFunc // only for ephemeral queues
+	ephemeral bool
+	ctx       context.Context
+}
+
+// QueueEphemeral creates a nameless, temporary queue. Caller must CloseEphemeral.
+func QueueEphemeral(ctx context.Context, options *EphemeralOptions) (*Queue, error) {
+	if options == nil {
+		options = &EphemeralOptions{}
+	}
+	ctx = clientContext(ctx)
+
+	resp, err := client.QueueGetOrCreate(ctx, pb.QueueGetOrCreateRequest_builder{
+		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
+		EnvironmentName:    environmentName(options.Environment),
+	}.Build())
+	if err != nil {
+		return nil, err
+	}
+
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	q := &Queue{QueueId: resp.GetQueueId(), cancel: cancel, ephemeral: true, ctx: ctx}
+
+	// backgroundheart‑beat goroutine
+	go func() {
+		t := time.NewTicker(ephemeralObjectHeartbeatSleep)
+		defer t.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-t.C:
+				_, _ = client.QueueHeartbeat(heartbeatCtx, pb.QueueHeartbeatRequest_builder{
+					QueueId: q.QueueId,
+				}.Build()) // ignore errors – next call will retry or context will cancel
+			}
+		}
+	}()
+
+	return q, nil
+}
+
+// CloseEphemeral deletes an ephemeral queue, only used with QueueEphemeral.
+func (q *Queue) CloseEphemeral() error {
+	if q.ephemeral {
+		q.cancel() // will stop heartbeat
+		return nil
+	} else {
+		return InvalidError{fmt.Sprintf("queue %s is not ephemeral", q.QueueId)}
+	}
+}
+
+// QueueLookup returns a handle to a (possibly new) queue by deployment name.
+func QueueLookup(ctx context.Context, name string, options *LookupOptions) (*Queue, error) {
+	if options == nil {
+		options = &LookupOptions{}
+	}
+	ctx = clientContext(ctx)
+
+	creationType := pb.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
+	if options.CreateIfMissing {
+		creationType = pb.ObjectCreationType_OBJECT_CREATION_TYPE_CREATE_IF_MISSING
+	}
+
+	resp, err := client.QueueGetOrCreate(ctx, pb.QueueGetOrCreateRequest_builder{
+		DeploymentName:     name,
+		Namespace:          pb.DeploymentNamespace_DEPLOYMENT_NAMESPACE_WORKSPACE,
+		EnvironmentName:    environmentName(options.Environment),
+		ObjectCreationType: creationType,
+	}.Build())
+	if err != nil {
+		return nil, err
+	}
+	return &Queue{ctx: ctx, QueueId: resp.GetQueueId()}, nil
+}
+
+// QueueDelete removes a queue by name.
+func QueueDelete(ctx context.Context, name string, options *DeleteOptions) error {
+	q, err := QueueLookup(ctx, name, &LookupOptions{Environment: options.Environment})
+	if err != nil {
+		return err
+	}
+	_, err = client.QueueDelete(ctx, pb.QueueDeleteRequest_builder{QueueId: q.QueueId}.Build())
+	return err
+}
+
+// Clear removes all objects from a queue partition.
+func (q *Queue) Clear(options *QueueClearOptions) error {
+	if options == nil {
+		options = &QueueClearOptions{}
+	}
+	if options.Partition != "" && options.All {
+		return InvalidError{"options.Partition must be \"\" when clearing all partitions"}
+	}
+	key, err := validatePartitionKey(options.Partition)
+	if err != nil {
+		return err
+	}
+	_, err = client.QueueClear(q.ctx, pb.QueueClearRequest_builder{
+		QueueId:       q.QueueId,
+		PartitionKey:  key,
+		AllPartitions: options.All,
+	}.Build())
+	return err
+}
+
+// internal helper for both Get and GetMany.
+func (q *Queue) get(n int, options *QueueGetOptions) ([]any, error) {
+	if options == nil {
+		options = &QueueGetOptions{}
+	}
+	partitionKey, err := validatePartitionKey(options.Partition)
+	if err != nil {
+		return nil, err
+	}
+
+	startTime := time.Now()
+	pollTimeout := 50 * time.Second
+	if options.Timeout != nil && pollTimeout > *options.Timeout {
+		pollTimeout = *options.Timeout
+	}
+
+	for {
+		resp, err := client.QueueGet(q.ctx, pb.QueueGetRequest_builder{
+			QueueId:      q.QueueId,
+			PartitionKey: partitionKey,
+			Timeout:      float32(pollTimeout.Seconds()),
+			NValues:      int32(n),
+		}.Build())
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.GetValues()) > 0 {
+			out := make([]any, len(resp.GetValues()))
+			for i, raw := range resp.GetValues() {
+				v, err := pickleDeserialize(raw)
+				if err != nil {
+					return nil, err
+				}
+				out[i] = v
+			}
+			return out, nil
+		}
+		if options.Timeout != nil {
+			remaining := *options.Timeout - time.Since(startTime)
+			if remaining <= 0 {
+				message := fmt.Sprintf("queue %s did not return values within %s", q.QueueId, *options.Timeout)
+				return nil, QueueEmptyError{message}
+			}
+			pollTimeout = min(pollTimeout, remaining)
+		}
+	}
+}
+
+// Get removes and returns one item (blocking by default).
+//
+// By default, this will wait until at least one item is present in the queue.
+// If `timeout` is set, returns `QueueEmptyError` if no items are available
+// within that timeout in milliseconds.
+func (q *Queue) Get(options *QueueGetOptions) (any, error) {
+	vals, err := q.get(1, options)
+	if err != nil {
+		return nil, err
+	}
+	return vals[0], nil // guaranteed len>=1
+}
+
+// GetMany removes up to n items.
+//
+// By default, this will wait until at least one item is present in the queue.
+// If `timeout` is set, returns `QueueEmptyError` if no items are available
+// within that timeout in milliseconds.
+func (q *Queue) GetMany(n int, options *QueueGetOptions) ([]any, error) {
+	return q.get(n, options)
+}
+
+// internal put helper (single/many).
+func (q *Queue) put(values []any, options *QueuePutOptions) error {
+	if options == nil {
+		options = &QueuePutOptions{}
+	}
+	key, err := validatePartitionKey(options.Partition)
+	if err != nil {
+		return err
+	}
+
+	valuesEncoded := make([][]byte, len(values))
+	for i, v := range values {
+		b, err := pickleSerialize(v)
+		if err != nil {
+			return err
+		}
+		valuesEncoded[i] = b.Bytes()
+	}
+
+	deadline := time.Time{}
+	if options.Timeout != nil {
+		deadline = time.Now().Add(*options.Timeout)
+	}
+
+	delay := 100 * time.Millisecond
+	ttl := options.PartitionTTL
+	if ttl == 0 {
+		ttl = 24 * time.Hour
+	}
+
+	for {
+		_, err := client.QueuePut(q.ctx, pb.QueuePutRequest_builder{
+			QueueId:             q.QueueId,
+			Values:              valuesEncoded,
+			PartitionKey:        key,
+			PartitionTtlSeconds: int32(ttl.Seconds()),
+		}.Build())
+		if err == nil {
+			return nil // success
+		}
+
+		if status.Code(err) != codes.ResourceExhausted {
+			return err
+		}
+
+		// Queue is full, retry with exponential backoff up to the deadline.
+		delay = min(delay*2, 30*time.Second)
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return QueueFullError{fmt.Sprintf("Put failed on %s", q.QueueId)}
+			}
+			delay = min(delay, remaining)
+		}
+		select {
+		case <-q.ctx.Done():
+			return q.ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// Put adds a single item to the end of the queue.
+//
+// If the queue is full, this will retry with exponential backoff until the
+// provided `timeout` is reached, or indefinitely if `timeout` is not set.
+// Raises `QueueFullError` if the queue is still full after the timeout.
+func (q *Queue) Put(v any, options *QueuePutOptions) error {
+	return q.put([]any{v}, options)
+}
+
+// PutMany adds multiple items to the end of the queue.
+//
+// If the queue is full, this will retry with exponential backoff until the
+// provided `timeout` is reached, or indefinitely if `timeout` is not set.
+// Raises `QueueFullError` if the queue is still full after the timeout.
+func (q *Queue) PutMany(values []any, options *QueuePutOptions) error {
+	return q.put(values, options)
+}
+
+// Len returns the number of objects in the queue.
+func (q *Queue) Len(options *QueueLenOptions) (int, error) {
+	if options == nil {
+		options = &QueueLenOptions{}
+	}
+	if options.Partition != "" && options.Total {
+		return 0, InvalidError{"partition must be empty when requesting total length"}
+	}
+	key, err := validatePartitionKey(options.Partition)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := client.QueueLen(q.ctx, pb.QueueLenRequest_builder{
+		QueueId:      q.QueueId,
+		PartitionKey: key,
+		Total:        options.Total,
+	}.Build())
+	if err != nil {
+		return 0, err
+	}
+	return int(resp.GetLen()), nil
+}
+
+// Iterate yields items without mutating the queue.
+func (q *Queue) Iterate(options *QueueIterateOptions) iter.Seq2[any, error] {
+	if options == nil {
+		options = &QueueIterateOptions{}
+	}
+
+	itemPoll := options.ItemPollTimeout
+	lastEntryID := ""
+	maxPoll := 30 * time.Second
+
+	return func(yield func(any, error) bool) {
+		key, err := validatePartitionKey(options.Partition)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		fetchDeadline := time.Now().Add(itemPoll)
+		for {
+			pollDuration := time.Until(fetchDeadline)
+			if pollDuration < 0 {
+				pollDuration = 0
+			}
+			if pollDuration > maxPoll {
+				pollDuration = maxPoll
+			}
+
+			resp, err := client.QueueNextItems(q.ctx, pb.QueueNextItemsRequest_builder{
+				QueueId:         q.QueueId,
+				PartitionKey:    key,
+				ItemPollTimeout: float32(pollDuration.Seconds()),
+				LastEntryId:     lastEntryID,
+			}.Build())
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if len(resp.GetItems()) > 0 {
+				for _, item := range resp.GetItems() {
+					v, err := pickleDeserialize(item.GetValue())
+					if err != nil {
+						return
+					}
+					if !yield(v, nil) {
+						return
+					}
+					lastEntryID = item.GetEntryId()
+				}
+				fetchDeadline = time.Now().Add(itemPoll)
+			} else if time.Now().After(fetchDeadline) {
+				return // exit on idle
+			}
+		}
+	}
+}

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -353,14 +353,7 @@ func (q *Queue) Iterate(options *QueueIterateOptions) iter.Seq2[any, error] {
 
 		fetchDeadline := time.Now().Add(itemPoll)
 		for {
-			pollDuration := time.Until(fetchDeadline)
-			if pollDuration < 0 {
-				pollDuration = 0
-			}
-			if pollDuration > maxPoll {
-				pollDuration = maxPoll
-			}
-
+			pollDuration := max(0, min(maxPoll, time.Until(fetchDeadline)))
 			resp, err := client.QueueNextItems(q.ctx, pb.QueueNextItemsRequest_builder{
 				QueueId:         q.QueueId,
 				PartitionKey:    key,

--- a/modal-go/test/queue_test.go
+++ b/modal-go/test/queue_test.go
@@ -1,0 +1,171 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modal-labs/libmodal/modal-go"
+	"github.com/onsi/gomega"
+)
+
+func TestQueueInvalidName(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	for _, name := range []string{"has space", "has/slash", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} {
+		_, err := modal.QueueLookup(context.Background(), name, nil)
+		g.Expect(err).Should(gomega.HaveOccurred(), "Queue lookup should fail for invalid name: %s", name)
+	}
+}
+
+func TestQueueEphemeral(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	queue, err := modal.QueueEphemeral(context.Background(), nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	defer queue.CloseEphemeral()
+
+	err = queue.Put(123, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	len, err := queue.Len(nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(len).To(gomega.Equal(1))
+
+	result, err := queue.Get(nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(int64(123)))
+}
+
+func TestQueueSuite1(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	queue, err := modal.QueueEphemeral(ctx, nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer queue.CloseEphemeral()
+
+	// queue.len() == 0
+	n, err := queue.Len(nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(n).To(gomega.Equal(0))
+
+	// put / len / get
+	g.Expect(queue.Put(123, nil)).ToNot(gomega.HaveOccurred())
+
+	n, err = queue.Len(nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(n).To(gomega.Equal(1))
+
+	item, err := queue.Get(nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(item).To(gomega.Equal(int64(123)))
+
+	// put, then non-blocking get
+	g.Expect(queue.Put(432, nil)).ToNot(gomega.HaveOccurred())
+
+	var timeout time.Duration
+	item, err = queue.Get(&modal.QueueGetOptions{Timeout: &timeout})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(item).To(gomega.Equal(int64(432)))
+
+	// queue is now empty – non-blocking get should error
+	_, err = queue.Get(&modal.QueueGetOptions{Timeout: &timeout})
+	g.Expect(errors.As(err, &modal.QueueEmptyError{})).To(gomega.BeTrue())
+
+	n, err = queue.Len(nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(n).To(gomega.Equal(0))
+
+	// putMany + iterator
+	g.Expect(queue.PutMany([]any{1, 2, 3}, nil)).ToNot(gomega.HaveOccurred())
+
+	results := make([]int64, 0, 3)
+	for v, err := range queue.Iterate(nil) {
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		results = append(results, v.(int64))
+	}
+	g.Expect(results).To(gomega.Equal([]int64{1, 2, 3}))
+}
+
+func TestQueueSuite2(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	queue, err := modal.QueueEphemeral(ctx, nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer queue.CloseEphemeral()
+
+	var wg sync.WaitGroup
+	results := make([]int64, 0, 10)
+
+	// producer
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range 10 {
+			_ = queue.Put(i, nil) // ignore error for brevity
+		}
+	}()
+
+	// consumer
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for v, err := range queue.Iterate(&modal.QueueIterateOptions{ItemPollTimeout: time.Second}) {
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			results = append(results, v.(int64))
+		}
+	}()
+
+	wg.Wait()
+	g.Expect(results).To(gomega.Equal([]int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}))
+}
+
+func TestQueuePutAndGetMany(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	queue, err := modal.QueueEphemeral(ctx, nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer queue.CloseEphemeral()
+
+	g.Expect(queue.PutMany([]any{1, 2, 3}, nil)).ToNot(gomega.HaveOccurred())
+
+	n, err := queue.Len(nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(n).To(gomega.Equal(3))
+
+	items, err := queue.GetMany(3, nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(items).To(gomega.Equal([]any{int64(1), int64(2), int64(3)}))
+}
+
+func TestQueueNonBlocking(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	queue, err := modal.QueueEphemeral(ctx, nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	defer queue.CloseEphemeral()
+
+	var timeout time.Duration
+	err = queue.Put(123, &modal.QueuePutOptions{Timeout: &timeout})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	n, err := queue.Len(nil)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(n).To(gomega.Equal(1))
+
+	item, err := queue.Get(&modal.QueueGetOptions{Timeout: &timeout})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(item).To(gomega.Equal(int64(123)))
+}

--- a/modal-js/test/queue.test.ts
+++ b/modal-js/test/queue.test.ts
@@ -33,9 +33,6 @@ test("QueueSuite1", async () => {
   const results: number[] = [];
   for await (const item of queue.iterate()) {
     results.push(item);
-    if (results.length === 3) {
-      break;
-    }
   }
   expect(results).toEqual([1, 2, 3]);
   queue.closeEphemeral();


### PR DESCRIPTION
Uses the new `iter.Seq2` type with `range` loops in Go 1.23.

```go
for item, err := range queue.Iterate(nil) {
	if err != nil {
		panic(err)
	}
	fmt.Println(item)
}
```