### PR TITLE
Add support for retrying internal failures

### DIFF
--- a/modal-js/src/input_strategy.ts
+++ b/modal-js/src/input_strategy.ts
@@ -9,10 +9,12 @@ import {
 import { client } from "./client";
 
 /**
- * There are two strategies for handling inputs:
- * 1. ControlPlaneStrategy: Send inputs to the control plane (the old way)
- * 2. InputPlaneStrategy: Send inputs to the input plane (the new way)
- * In the spirit of being forward looking, the interface matches the new input plane API.
+ * This abstraction exists so that we can easily send inputs to either the control plane or the input plane.
+ * Function definitions that inlcude an option like this `experimental_options={"input_plane_region": "us-west"}`
+ * are sent to the input plane, otherwise they are sent to the control plane.
+ *
+ * Once the input plane is no longer experimental, and all user traffic has been moved to it, we can remove
+ * this abstraction.
  */
 export interface InputStrategy {
   attemptStart(): Promise<void>;

--- a/modal-js/src/input_strategy.ts
+++ b/modal-js/src/input_strategy.ts
@@ -1,0 +1,143 @@
+import {
+  FunctionCallInvocationType,
+  FunctionCallType,
+  FunctionGetOutputsItem,
+  FunctionPutInputsItem,
+  FunctionRetryInputsItem,
+  ModalClientClient,
+} from "../proto/modal_proto/api";
+import { client } from "./client";
+
+/**
+ * There are two strategies for handling inputs:
+ * 1. ControlPlaneStrategy: Send inputs to the control plane (the old way)
+ * 2. InputPlaneStrategy: Send inputs to the input plane (the new way)
+ * In the spirit of being forward looking, the interface matches the new input plane API.
+ */
+export interface InputStrategy {
+  attemptStart(): Promise<void>;
+  attemptRetry(): Promise<void>;
+  attemptAwait(timeout_seconds: number): Promise<FunctionGetOutputsItem[]>;
+}
+
+/**
+ * Implementation of InputStrategy which sends inputs to the control plane.
+ */
+export class ControlPlaneStrategy implements InputStrategy {
+  private readonly client: ModalClientClient;
+  private readonly functionId: string;
+  private readonly input: FunctionPutInputsItem;
+  private readonly invocationType: FunctionCallInvocationType;
+  private functionCallJwt: string | undefined;
+  private inputJwt: string | undefined;
+  functionCallId: string | undefined;
+
+  constructor(
+    client: ModalClientClient,
+    functionId: string,
+    input: FunctionPutInputsItem,
+    invocationType: FunctionCallInvocationType,
+  ) {
+    this.client = client;
+    this.functionId = functionId;
+    this.input = input;
+    this.invocationType = invocationType;
+  }
+
+  async attemptStart(): Promise<void> {
+    const functionMapResponse = await this.client.functionMap({
+      functionId: this.functionId,
+      functionCallType: FunctionCallType.FUNCTION_CALL_TYPE_UNARY,
+      functionCallInvocationType: this.invocationType,
+      pipelinedInputs: [this.input],
+    });
+
+    this.functionCallId = functionMapResponse.functionCallId;
+    this.functionCallJwt = functionMapResponse.functionCallJwt;
+    this.inputJwt = functionMapResponse.pipelinedInputs[0].inputJwt;
+  }
+
+  async attemptRetry(): Promise<void> {
+    const retryItem: FunctionRetryInputsItem = {
+      inputJwt: this.inputJwt!,
+      input: this.input.input!,
+      retryCount: 0,
+    };
+    const functionRetryResponse = await client.functionRetryInputs({
+      functionCallJwt: this.functionCallJwt,
+      inputs: [retryItem],
+    });
+    this.inputJwt = functionRetryResponse.inputJwts[0];
+  }
+
+  async attemptAwait(timeoutMillis: number): Promise<FunctionGetOutputsItem[]> {
+    try {
+      const response = await this.client.functionGetOutputs({
+        functionCallId: this.functionCallId,
+        maxValues: 1,
+        timeout: timeoutMillis / 1000,
+        lastEntryId: "0-0",
+        clearOnSuccess: true,
+        requestedAt: timeNowSeconds(),
+        inputJwts: [this.inputJwt!],
+      });
+      return response.outputs;
+    } catch (err) {
+      throw new Error(`FunctionGetOutputs failed: ${err}`);
+    }
+  }
+}
+
+/**
+ * Implementation of InputStrategy which sends inputs to the input plane.
+ */
+export class InputPlaneStrategy implements InputStrategy {
+  private readonly client: ModalClientClient;
+  private readonly functionId: string;
+  private readonly input: FunctionPutInputsItem;
+  private attemptToken: string | undefined;
+
+  constructor(
+    client: ModalClientClient,
+    functionId: string,
+    input: FunctionPutInputsItem,
+  ) {
+    this.client = client;
+    this.functionId = functionId;
+    this.input = input;
+  }
+
+  async attemptStart(): Promise<void> {
+    const attemptStartResponse = await this.client.attemptStart({
+      functionId: this.functionId,
+      input: this.input,
+    });
+    this.attemptToken = attemptStartResponse.attemptToken;
+  }
+
+  async attemptRetry(): Promise<void> {
+    const attemptRetryResponse = await this.client.attemptRetry({
+      functionId: this.functionId,
+      input: this.input,
+      attemptToken: this.attemptToken,
+    });
+    this.attemptToken = attemptRetryResponse.attemptToken;
+  }
+
+  async attemptAwait(timeoutMillis: number): Promise<FunctionGetOutputsItem[]> {
+    try {
+      const response = await this.client.attemptAwait({
+        attemptToken: this.attemptToken,
+        requestedAt: timeNowSeconds(),
+        timeoutSecs: timeoutMillis / 1000,
+      });
+      return response.output ? [response.output] : [];
+    } catch (err) {
+      throw new Error(`AttemptAwait failed: ${err}`);
+    }
+  }
+}
+
+function timeNowSeconds() {
+  return Date.now() / 1e3;
+}

--- a/modal-js/src/input_strategy.ts
+++ b/modal-js/src/input_strategy.ts
@@ -10,7 +10,7 @@ import { client } from "./client";
 
 /**
  * This abstraction exists so that we can easily send inputs to either the control plane or the input plane.
- * Function definitions that inlcude an option like this `experimental_options={"input_plane_region": "us-west"}`
+ * Function definitions that include an option like this `experimental_options={"input_plane_region": "us-west"}`
  * are sent to the input plane, otherwise they are sent to the control plane.
  *
  * Once the input plane is no longer experimental, and all user traffic has been moved to it, we can remove

--- a/modal-js/test/function_call.test.ts
+++ b/modal-js/test/function_call.test.ts
@@ -9,7 +9,7 @@ test("FunctionSpawn", async () => {
 
   // Spawn function with kwargs.
   let functionCall = await function_.spawn([], { s: "hello" });
-  expect(functionCall.functionOutputPoller.functionCallId).toBeDefined();
+  expect(functionCall.inputStrategy.functionCallId).toBeDefined();
 
   // Get results after spawn.
   let resultKwargs = await functionCall.get();
@@ -24,7 +24,7 @@ test("FunctionSpawn", async () => {
 
   // Spawn with long running input.
   functionCall = await sleep.spawn([], { t: 5 });
-  expect(functionCall.functionOutputPoller.functionCallId).toBeDefined();
+  expect(functionCall.inputStrategy.functionCallId).toBeDefined();
 
   // Getting outputs with timeout raises error.
   const promise = functionCall.get({ timeout: 1000 }); // 1000ms


### PR DESCRIPTION
This is based on https://github.com/modal-labs/libmodal/pull/15.

Note: Please review typescript only! Everything described below hasn't been implemented in go yet. If the typescript looks good, I'll do the same in go.

This builds on the above PR in the following ways:
* Retries up to 8 times on INTERNAL_FAILURE which can happen if inputs are lost for some reason. 
* Adds InputStrategy interface, which provides a uniform API for sending inputs to both the input plane and control plane. The interface is implemented by two classes: InputPlaneStrategy and ControlPlaneStrategy. The client will decide which to use based on the function configuration - specifically if the function definition has an input plane region specified. 

