### PR TITLE
[WIP] Allow instantiating clients from credentials

### DIFF
--- a/modal-js/src/app.ts
+++ b/modal-js/src/app.ts
@@ -57,7 +57,7 @@ export class App {
   /** Lookup a deployed app by name, or create if it does not exist. */
   static async lookup(name: string, options: LookupOptions = {}): Promise<App> {
     try {
-      const resp = await client.appGetOrCreate({
+      const resp = await client.stub.appGetOrCreate({
         appName: name,
         environmentName: environmentName(options.environment),
         objectCreationType: options.createIfMissing
@@ -83,7 +83,7 @@ export class App {
       );
     }
 
-    const createResp = await client.sandboxCreate({
+    const createResp = await client.stub.sandboxCreate({
       appId: this.appId,
       definition: {
         // Sleep default is implicit in image builder version <=2024.10

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -4,6 +4,7 @@ import {
   ClientError,
   ClientMiddleware,
   ClientMiddlewareCall,
+  type Client,
   createChannel,
   createClientFactory,
   Metadata,
@@ -197,8 +198,21 @@ const channel = createChannel(profile.serverUrl, undefined, {
   "grpc-node.flow_control_window": 64 * 1024 * 1024,
 });
 
-export const client = createClientFactory()
-  .use(authMiddleware(profile))
-  .use(retryMiddleware)
-  .use(timeoutMiddleware)
-  .create(ModalClientDefinition, channel);
+export class ModalClient {
+  stub: Client<ModalClientDefinition>;
+
+  constructor(options: { tokenId?: string; tokenSecret?: string } = {}) {
+    const { tokenId, tokenSecret } = options;
+
+    const profileToUse =
+      tokenId && tokenSecret ? { ...profile, tokenId, tokenSecret } : profile;
+
+    this.stub = createClientFactory()
+      .use(authMiddleware(profileToUse))
+      .use(retryMiddleware)
+      .use(timeoutMiddleware)
+      .create(ModalClientDefinition, channel);
+  }
+}
+
+export const client = new ModalClient();

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -215,4 +215,4 @@ export class ModalClient {
   }
 }
 
-export const client = new ModalClient();
+export const defaultClient = new ModalClient();

--- a/modal-js/src/cls.ts
+++ b/modal-js/src/cls.ts
@@ -37,7 +37,7 @@ export class Cls {
   ): Promise<Cls> {
     try {
       const serviceFunctionName = `${name}.*`;
-      const serviceFunction = await client.functionGet({
+      const serviceFunction = await client.stub.functionGet({
         appName,
         objectTag: serviceFunctionName,
         namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -93,7 +93,7 @@ export class Cls {
   /** Bind parameters to the Cls function. */
   async #bindParameters(params: Record<string, any>): Promise<string> {
     const serializedParams = encodeParameterSet(this.#schema, params);
-    const bindResp = await client.functionBindParams({
+    const bindResp = await client.stub.functionBindParams({
       functionId: this.#serviceFunctionId,
       serializedParams,
     });

--- a/modal-js/src/cls.ts
+++ b/modal-js/src/cls.ts
@@ -9,7 +9,7 @@ import {
 } from "../proto/modal_proto/api";
 import type { LookupOptions } from "./app";
 import { NotFoundError } from "./errors";
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { environmentName } from "./config";
 import { Function_ } from "./function";
 
@@ -37,7 +37,7 @@ export class Cls {
   ): Promise<Cls> {
     try {
       const serviceFunctionName = `${name}.*`;
-      const serviceFunction = await client.stub.functionGet({
+      const serviceFunction = await defaultClient.stub.functionGet({
         appName,
         objectTag: serviceFunctionName,
         namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -93,7 +93,7 @@ export class Cls {
   /** Bind parameters to the Cls function. */
   async #bindParameters(params: Record<string, any>): Promise<string> {
     const serializedParams = encodeParameterSet(this.#schema, params);
-    const bindResp = await client.stub.functionBindParams({
+    const bindResp = await defaultClient.stub.functionBindParams({
       functionId: this.#serviceFunctionId,
       serializedParams,
     });

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -9,7 +9,7 @@ import {
   FunctionInput,
 } from "../proto/modal_proto/api";
 import type { LookupOptions } from "./app";
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { FunctionCall } from "./function_call";
 import { environmentName } from "./config";
 import { InternalFailure, NotFoundError } from "./errors";
@@ -40,7 +40,7 @@ export class Function_ {
     options: LookupOptions = {},
   ): Promise<Function_> {
     try {
-      const resp = await client.stub.functionGet({
+      const resp = await defaultClient.stub.functionGet({
         appName,
         objectTag: name,
         namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -120,7 +120,7 @@ export class Function_ {
 async function blobUpload(data: Uint8Array): Promise<string> {
   const contentMd5 = createHash("md5").update(data).digest("base64");
   const contentSha256 = createHash("sha256").update(data).digest("base64");
-  const resp = await client.stub.blobCreate({
+  const resp = await defaultClient.stub.blobCreate({
     contentMd5,
     contentSha256Base64: contentSha256,
     contentLength: data.length,

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -40,7 +40,7 @@ export class Function_ {
     options: LookupOptions = {},
   ): Promise<Function_> {
     try {
-      const resp = await client.functionGet({
+      const resp = await client.stub.functionGet({
         appName,
         objectTag: name,
         namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -120,7 +120,7 @@ export class Function_ {
 async function blobUpload(data: Uint8Array): Promise<string> {
   const contentMd5 = createHash("md5").update(data).digest("base64");
   const contentSha256 = createHash("sha256").update(data).digest("base64");
-  const resp = await client.blobCreate({
+  const resp = await client.stub.blobCreate({
     contentMd5,
     contentSha256Base64: contentSha256,
     contentLength: data.length,

--- a/modal-js/src/function_call.ts
+++ b/modal-js/src/function_call.ts
@@ -1,6 +1,6 @@
 // Manage existing Function Calls (look-ups, polling for output, cancellation).
 
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { ControlPlaneInvocation } from "./invocation";
 
 /** Options for `FunctionCall.get()`. */
@@ -42,7 +42,7 @@ export class FunctionCall {
 
   /** Cancel a running function call. */
   async cancel(options: FunctionCallCancelOptions = {}) {
-    await client.stub.functionCallCancel({
+    await defaultClient.stub.functionCallCancel({
       functionCallId: this.functionCallId,
       terminateContainers: options.terminateContainers,
     });

--- a/modal-js/src/function_call.ts
+++ b/modal-js/src/function_call.ts
@@ -42,7 +42,7 @@ export class FunctionCall {
 
   /** Cancel a running function call. */
   async cancel(options: FunctionCallCancelOptions = {}) {
-    await client.functionCallCancel({
+    await client.stub.functionCallCancel({
       functionCallId: this.functionCallId,
       terminateContainers: options.terminateContainers,
     });

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -23,7 +23,7 @@ export async function fromRegistryInternal(
   tag: string,
   imageRegistryConfig?: ImageRegistryConfig,
 ): Promise<Image> {
-  const resp = await client.imageGetOrCreate({
+  const resp = await client.stub.imageGetOrCreate({
     appId,
     image: {
       dockerfileCommands: [`FROM ${tag}`],
@@ -45,7 +45,7 @@ export async function fromRegistryInternal(
     let lastEntryId = "";
     let resultJoined: GenericResult | undefined = undefined;
     while (!resultJoined) {
-      for await (const item of client.imageJoinStreaming({
+      for await (const item of client.stub.imageJoinStreaming({
         imageId: resp.imageId,
         timeout: 55,
         lastEntryId,

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -5,7 +5,7 @@ import {
   ImageMetadata,
   ImageRegistryConfig,
 } from "../proto/modal_proto/api";
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { imageBuilderVersion } from "./config";
 
 /** A container image, used for starting sandboxes. */
@@ -23,7 +23,7 @@ export async function fromRegistryInternal(
   tag: string,
   imageRegistryConfig?: ImageRegistryConfig,
 ): Promise<Image> {
-  const resp = await client.stub.imageGetOrCreate({
+  const resp = await defaultClient.stub.imageGetOrCreate({
     appId,
     image: {
       dockerfileCommands: [`FROM ${tag}`],
@@ -45,7 +45,7 @@ export async function fromRegistryInternal(
     let lastEntryId = "";
     let resultJoined: GenericResult | undefined = undefined;
     while (!resultJoined) {
-      for await (const item of client.stub.imageJoinStreaming({
+      for await (const item of defaultClient.stub.imageJoinStreaming({
         imageId: resp.imageId,
         timeout: 55,
         lastEntryId,

--- a/modal-js/src/invocation.ts
+++ b/modal-js/src/invocation.ts
@@ -58,7 +58,7 @@ export class ControlPlaneInvocation implements Invocation {
       input,
     };
 
-    const functionMapResponse = await client.functionMap({
+    const functionMapResponse = await client.stub.functionMap({
       functionId,
       functionCallType: FunctionCallType.FUNCTION_CALL_TYPE_UNARY,
       functionCallInvocationType: invocationType,
@@ -93,7 +93,7 @@ export class ControlPlaneInvocation implements Invocation {
       retryCount,
     };
 
-    const functionRetryResponse = await client.functionRetryInputs({
+    const functionRetryResponse = await client.stub.functionRetryInputs({
       functionCallJwt: this.functionCallJwt,
       inputs: [retryItem],
     });
@@ -118,7 +118,7 @@ export async function pollFunctionOutput(
   while (true) {
     let response: FunctionGetOutputsResponse;
     try {
-      response = await client.functionGetOutputs({
+      response = await client.stub.functionGetOutputs({
         functionCallId,
         maxValues: 1,
         timeout: pollTimeout / 1000, // Backend needs seconds
@@ -178,7 +178,7 @@ async function processResult(
 }
 
 async function blobDownload(blobId: string): Promise<Uint8Array> {
-  const resp = await client.blobGet({ blobId });
+  const resp = await client.stub.blobGet({ blobId });
   const s3resp = await fetch(resp.downloadUrl);
   if (!s3resp.ok) {
     throw new Error(`Failed to download blob: ${s3resp.statusText}`);

--- a/modal-js/src/invocation.ts
+++ b/modal-js/src/invocation.ts
@@ -9,7 +9,7 @@ import {
   GenericResult,
   GenericResult_GenericStatus,
 } from "../proto/modal_proto/api";
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { FunctionTimeoutError, InternalFailure, RemoteError } from "./errors";
 import { loads } from "./pickle";
 
@@ -58,7 +58,7 @@ export class ControlPlaneInvocation implements Invocation {
       input,
     };
 
-    const functionMapResponse = await client.stub.functionMap({
+    const functionMapResponse = await defaultClient.stub.functionMap({
       functionId,
       functionCallType: FunctionCallType.FUNCTION_CALL_TYPE_UNARY,
       functionCallInvocationType: invocationType,
@@ -93,7 +93,7 @@ export class ControlPlaneInvocation implements Invocation {
       retryCount,
     };
 
-    const functionRetryResponse = await client.stub.functionRetryInputs({
+    const functionRetryResponse = await defaultClient.stub.functionRetryInputs({
       functionCallJwt: this.functionCallJwt,
       inputs: [retryItem],
     });
@@ -118,7 +118,7 @@ export async function pollFunctionOutput(
   while (true) {
     let response: FunctionGetOutputsResponse;
     try {
-      response = await client.stub.functionGetOutputs({
+      response = await defaultClient.stub.functionGetOutputs({
         functionCallId,
         maxValues: 1,
         timeout: pollTimeout / 1000, // Backend needs seconds
@@ -178,7 +178,7 @@ async function processResult(
 }
 
 async function blobDownload(blobId: string): Promise<Uint8Array> {
-  const resp = await client.stub.blobGet({ blobId });
+  const resp = await defaultClient.stub.blobGet({ blobId });
   const s3resp = await fetch(resp.downloadUrl);
   if (!s3resp.ok) {
     throw new Error(`Failed to download blob: ${s3resp.statusText}`);

--- a/modal-js/src/queue.ts
+++ b/modal-js/src/queue.ts
@@ -6,7 +6,7 @@ import {
   QueueNextItemsRequest,
 } from "../proto/modal_proto/api";
 import type { DeleteOptions, EphemeralOptions, LookupOptions } from "./app";
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { environmentName } from "./config";
 import { InvalidError, QueueEmptyError, QueueFullError } from "./errors";
 import { dumps, loads } from "./pickle";
@@ -99,7 +99,7 @@ export class Queue {
    * You will need to call `closeEphemeral()` to delete the queue.
    */
   static async ephemeral(options: EphemeralOptions = {}): Promise<Queue> {
-    const resp = await client.stub.queueGetOrCreate({
+    const resp = await defaultClient.stub.queueGetOrCreate({
       objectCreationType: ObjectCreationType.OBJECT_CREATION_TYPE_EPHEMERAL,
       environmentName: environmentName(options.environment),
     });
@@ -109,7 +109,7 @@ export class Queue {
     (async () => {
       // Launch a background task to heartbeat the ephemeral queue.
       while (true) {
-        await client.stub.queueHeartbeat({ queueId: resp.queueId });
+        await defaultClient.stub.queueHeartbeat({ queueId: resp.queueId });
         await Promise.race([
           new Promise((resolve) =>
             setTimeout(resolve, ephemeralObjectHeartbeatSleep),
@@ -140,7 +140,7 @@ export class Queue {
     name: string,
     options: LookupOptions = {},
   ): Promise<Queue> {
-    const resp = await client.stub.queueGetOrCreate({
+    const resp = await defaultClient.stub.queueGetOrCreate({
       deploymentName: name,
       objectCreationType: options.createIfMissing
         ? ObjectCreationType.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
@@ -157,7 +157,7 @@ export class Queue {
     options: DeleteOptions = {},
   ): Promise<void> {
     const queue = await Queue.lookup(name, options);
-    await client.stub.queueDelete({ queueId: queue.queueId });
+    await defaultClient.stub.queueDelete({ queueId: queue.queueId });
   }
 
   /**
@@ -169,7 +169,7 @@ export class Queue {
         "Partition must be null when requesting to clear all.",
       );
     }
-    await client.stub.queueClear({
+    await defaultClient.stub.queueClear({
       queueId: this.queueId,
       partitionKey: Queue.#validatePartitionKey(options.partition),
       allPartitions: options.all,
@@ -186,7 +186,7 @@ export class Queue {
     }
 
     while (true) {
-      const response = await client.stub.queueGet({
+      const response = await defaultClient.stub.queueGet({
         queueId: this.queueId,
         partitionKey,
         timeout: pollTimeout / 1000,
@@ -242,7 +242,7 @@ export class Queue {
     const deadline = timeout ? Date.now() + timeout : undefined;
     while (true) {
       try {
-        await client.stub.queuePut({
+        await defaultClient.stub.queuePut({
           queueId: this.queueId,
           values: valuesEncoded,
           partitionKey,
@@ -307,7 +307,7 @@ export class Queue {
         "Partition must be null when requesting total length.",
       );
     }
-    const resp = await client.stub.queueLen({
+    const resp = await defaultClient.stub.queueLen({
       queueId: this.queueId,
       partitionKey: Queue.#validatePartitionKey(options.partition),
       total: options.total,
@@ -338,7 +338,7 @@ export class Queue {
         lastEntryId: lastEntryId || "",
       };
 
-      const response = await client.stub.queueNextItems(request);
+      const response = await defaultClient.stub.queueNextItems(request);
       if (response.items && response.items.length > 0) {
         for (const item of response.items) {
           yield loads(item.value);

--- a/modal-js/src/queue.ts
+++ b/modal-js/src/queue.ts
@@ -99,7 +99,7 @@ export class Queue {
    * You will need to call `closeEphemeral()` to delete the queue.
    */
   static async ephemeral(options: EphemeralOptions = {}): Promise<Queue> {
-    const resp = await client.queueGetOrCreate({
+    const resp = await client.stub.queueGetOrCreate({
       objectCreationType: ObjectCreationType.OBJECT_CREATION_TYPE_EPHEMERAL,
       environmentName: environmentName(options.environment),
     });
@@ -109,7 +109,7 @@ export class Queue {
     (async () => {
       // Launch a background task to heartbeat the ephemeral queue.
       while (true) {
-        await client.queueHeartbeat({ queueId: resp.queueId });
+        await client.stub.queueHeartbeat({ queueId: resp.queueId });
         await Promise.race([
           new Promise((resolve) =>
             setTimeout(resolve, ephemeralObjectHeartbeatSleep),
@@ -140,7 +140,7 @@ export class Queue {
     name: string,
     options: LookupOptions = {},
   ): Promise<Queue> {
-    const resp = await client.queueGetOrCreate({
+    const resp = await client.stub.queueGetOrCreate({
       deploymentName: name,
       objectCreationType: options.createIfMissing
         ? ObjectCreationType.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
@@ -157,7 +157,7 @@ export class Queue {
     options: DeleteOptions = {},
   ): Promise<void> {
     const queue = await Queue.lookup(name, options);
-    await client.queueDelete({ queueId: queue.queueId });
+    await client.stub.queueDelete({ queueId: queue.queueId });
   }
 
   /**
@@ -169,7 +169,7 @@ export class Queue {
         "Partition must be null when requesting to clear all.",
       );
     }
-    await client.queueClear({
+    await client.stub.queueClear({
       queueId: this.queueId,
       partitionKey: Queue.#validatePartitionKey(options.partition),
       allPartitions: options.all,
@@ -186,7 +186,7 @@ export class Queue {
     }
 
     while (true) {
-      const response = await client.queueGet({
+      const response = await client.stub.queueGet({
         queueId: this.queueId,
         partitionKey,
         timeout: pollTimeout / 1000,
@@ -242,7 +242,7 @@ export class Queue {
     const deadline = timeout ? Date.now() + timeout : undefined;
     while (true) {
       try {
-        await client.queuePut({
+        await client.stub.queuePut({
           queueId: this.queueId,
           values: valuesEncoded,
           partitionKey,
@@ -307,7 +307,7 @@ export class Queue {
         "Partition must be null when requesting total length.",
       );
     }
-    const resp = await client.queueLen({
+    const resp = await client.stub.queueLen({
       queueId: this.queueId,
       partitionKey: Queue.#validatePartitionKey(options.partition),
       total: options.total,
@@ -338,7 +338,7 @@ export class Queue {
         lastEntryId: lastEntryId || "",
       };
 
-      const response = await client.queueNextItems(request);
+      const response = await client.stub.queueNextItems(request);
       if (response.items && response.items.length > 0) {
         for (const item of response.items) {
           yield loads(item.value);

--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -1,5 +1,5 @@
 import { FileDescriptor } from "../proto/modal_proto/api";
-import { client, isRetryableGrpc } from "./client";
+import { defaultClient, isRetryableGrpc } from "./client";
 import {
   runFilesystemExec,
   SandboxFile,
@@ -101,7 +101,7 @@ export class Sandbox {
   ): Promise<ContainerProcess> {
     const taskId = await this.#getTaskId();
 
-    const resp = await client.stub.containerExec({
+    const resp = await defaultClient.stub.containerExec({
       taskId,
       command,
     });
@@ -111,7 +111,7 @@ export class Sandbox {
 
   async #getTaskId(): Promise<string> {
     if (this.#taskId === undefined) {
-      const resp = await client.stub.sandboxGetTaskId({
+      const resp = await defaultClient.stub.sandboxGetTaskId({
         sandboxId: this.sandboxId,
       });
       if (!resp.taskId) {
@@ -130,13 +130,13 @@ export class Sandbox {
   }
 
   async terminate(): Promise<void> {
-    await client.stub.sandboxTerminate({ sandboxId: this.sandboxId });
+    await defaultClient.stub.sandboxTerminate({ sandboxId: this.sandboxId });
     this.#taskId = undefined; // Reset task ID after termination
   }
 
   async wait(): Promise<number> {
     while (true) {
-      const resp = await client.stub.sandboxWait({
+      const resp = await defaultClient.stub.sandboxWait({
         sandboxId: this.sandboxId,
         timeout: 55,
       });
@@ -196,7 +196,7 @@ export class ContainerProcess<R extends string | Uint8Array = any> {
   /** Wait for process completion and return the exit code. */
   async wait(): Promise<number> {
     while (true) {
-      const resp = await client.stub.containerExecWait({
+      const resp = await defaultClient.stub.containerExecWait({
         execId: this.#execId,
         timeout: 55,
       });
@@ -217,7 +217,7 @@ async function* outputStreamSb(
   let retries = 10;
   while (!completed) {
     try {
-      const outputIterator = client.stub.sandboxGetLogs({
+      const outputIterator = defaultClient.stub.sandboxGetLogs({
         sandboxId,
         fileDescriptor,
         timeout: 55,
@@ -248,7 +248,7 @@ async function* outputStreamCp(
   let retries = 10;
   while (!completed) {
     try {
-      const outputIterator = client.stub.containerExecGetOutput({
+      const outputIterator = defaultClient.stub.containerExecGetOutput({
         execId,
         fileDescriptor,
         timeout: 55,
@@ -276,7 +276,7 @@ function inputStreamSb(sandboxId: string): WritableStream<string> {
   let index = 1;
   return new WritableStream<string>({
     async write(chunk) {
-      await client.stub.sandboxStdinWrite({
+      await defaultClient.stub.sandboxStdinWrite({
         sandboxId,
         input: encodeIfString(chunk),
         index,
@@ -284,7 +284,7 @@ function inputStreamSb(sandboxId: string): WritableStream<string> {
       index++;
     },
     async close() {
-      await client.stub.sandboxStdinWrite({
+      await defaultClient.stub.sandboxStdinWrite({
         sandboxId,
         index,
         eof: true,
@@ -299,7 +299,7 @@ function inputStreamCp<R extends string | Uint8Array>(
   let messageIndex = 1;
   return new WritableStream<R>({
     async write(chunk) {
-      await client.stub.containerExecPutInput({
+      await defaultClient.stub.containerExecPutInput({
         execId,
         input: {
           message: encodeIfString(chunk),
@@ -309,7 +309,7 @@ function inputStreamCp<R extends string | Uint8Array>(
       messageIndex++;
     },
     async close() {
-      await client.stub.containerExecPutInput({
+      await defaultClient.stub.containerExecPutInput({
         execId,
         input: {
           messageIndex,

--- a/modal-js/src/sandbox_filesystem.ts
+++ b/modal-js/src/sandbox_filesystem.ts
@@ -93,14 +93,14 @@ export async function runFilesystemExec(
   chunks: Uint8Array[];
   response: ContainerFilesystemExecResponse;
 }> {
-  const response = await client.containerFilesystemExec(request);
+  const response = await client.stub.containerFilesystemExec(request);
 
   const chunks: Uint8Array[] = [];
   let retries = 10;
   let completed = false;
   while (!completed) {
     try {
-      const outputIterator = client.containerFilesystemExecGetOutput({
+      const outputIterator = client.stub.containerFilesystemExecGetOutput({
         execId: response.execId,
         timeout: 55,
       });

--- a/modal-js/src/sandbox_filesystem.ts
+++ b/modal-js/src/sandbox_filesystem.ts
@@ -3,7 +3,7 @@ import {
   DeepPartial,
   ContainerFilesystemExecResponse,
 } from "../proto/modal_proto/api";
-import { client, isRetryableGrpc } from "./client";
+import { defaultClient, isRetryableGrpc } from "./client";
 import { SandboxFilesystemError } from "./errors";
 
 /** File open modes supported by the filesystem API. */
@@ -93,17 +93,18 @@ export async function runFilesystemExec(
   chunks: Uint8Array[];
   response: ContainerFilesystemExecResponse;
 }> {
-  const response = await client.stub.containerFilesystemExec(request);
+  const response = await defaultClient.stub.containerFilesystemExec(request);
 
   const chunks: Uint8Array[] = [];
   let retries = 10;
   let completed = false;
   while (!completed) {
     try {
-      const outputIterator = client.stub.containerFilesystemExecGetOutput({
-        execId: response.execId,
-        timeout: 55,
-      });
+      const outputIterator =
+        defaultClient.stub.containerFilesystemExecGetOutput({
+          execId: response.execId,
+          timeout: 55,
+        });
       for await (const batch of outputIterator) {
         chunks.push(...batch.output);
         if (batch.eof) {

--- a/modal-js/src/secret.ts
+++ b/modal-js/src/secret.ts
@@ -25,7 +25,7 @@ export class Secret {
     options?: SecretFromNameOptions,
   ): Promise<Secret> {
     try {
-      const resp = await client.secretGetOrCreate({
+      const resp = await client.stub.secretGetOrCreate({
         deploymentName: name,
         namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environmentName: configEnvironmentName(options?.environment),

--- a/modal-js/src/secret.ts
+++ b/modal-js/src/secret.ts
@@ -1,5 +1,5 @@
 import { DeploymentNamespace } from "../proto/modal_proto/api";
-import { client } from "./client";
+import { defaultClient } from "./client";
 import { environmentName as configEnvironmentName } from "./config";
 import { ClientError, Status } from "nice-grpc";
 import { NotFoundError } from "./errors";
@@ -25,7 +25,7 @@ export class Secret {
     options?: SecretFromNameOptions,
   ): Promise<Secret> {
     try {
-      const resp = await client.stub.secretGetOrCreate({
+      const resp = await defaultClient.stub.secretGetOrCreate({
         deploymentName: name,
         namespace: DeploymentNamespace.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environmentName: configEnvironmentName(options?.environment),


### PR DESCRIPTION
Adds a class `ModalClient` that can be instantiated with `{tokenId, tokenSecret}` and passed to sandbox creation methods. 

Unfortunately this means we need to propagate `client` to a lot of places, just like we do in the Python client. I think this is necessary because we want users to have several sandboxes coexist with separate sets of credentials.

Renamed the existing global `client` singleton to `defaultClient`. Function/cls invocation currently still uses the `defaultClient` everywhere.

## TODO

- [ ] Go support
- [ ] Tests