### PR TITLE
Split up `npm version` and `npm publish` steps

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -43,7 +43,8 @@ This gRPC library depends on the `protobuf-ts` package, which is not compatible 
 Update `CHANGELOG.md`. Make sure that you're on a clean commit, then:
 
 ```bash
-npm version patch  # will build, bump the version, commit, tag, push, and npm publish
+npm version patch  # or 'minor' - makes a commit, check changes look good!
+npm publish  # publish to npm, add git tag, push
 ```
 
 ```bash

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -33,7 +33,8 @@
     "lint": "eslint",
     "prepare": "scripts/gen-proto.sh",
     "test": "vitest",
-    "version": "npm run build && git add package.json package-lock.json && git commit -m \"modal-js/v$npm_package_version\"",
+    "version": "npm run check && git add package.json package-lock.json && git commit -m \"modal-js/v$npm_package_version\"",
+    "prepublishOnly": "npm run build && git push",
     "postpublish": "git tag modal-js/v$npm_package_version && git push --tags"
   },
   "dependencies": {

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -33,9 +33,8 @@
     "lint": "eslint",
     "prepare": "scripts/gen-proto.sh",
     "test": "vitest",
-    "preversion": "(git update-index --really-refresh && git diff-index --quiet HEAD) || (echo 'You must commit all changes before running npm version' && exit 1)",
-    "version": "npm run build && git add package.json package-lock.json && git commit -m \"modal-js/v$npm_package_version\" && git tag modal-js/v$npm_package_version",
-    "postversion": "git push && git push --tags && npm publish"
+    "version": "npm run build && git add package.json package-lock.json && git commit -m \"modal-js/v$npm_package_version\"",
+    "postpublish": "git tag modal-js/v$npm_package_version && git push --tags"
   },
   "dependencies": {
     "long": "^5.3.1",


### PR DESCRIPTION
Trying to make the modal-js publishing workflow less risky, this splits up the version bump and the publish step so that `npm version patch` with the wrong identifier doesn't publish an invalid version.