### PR TITLE
Add initializeClient and do not panic at startup if missing token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
-No unreleased changes.
+- Add `InitializeClient()` (Go) / `initializeClient()` (TS) to initialize the client at runtime with credentials.
+- Client libraries no longer panic at startup if no token ID / secret is provided. Instead, they will throw an error when trying to use the client.
 
 ## modal-js/v0.3.10, modal-go/v0.0.10
 

--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -45,7 +45,11 @@ func AppLookup(ctx context.Context, name string, options *LookupOptions) (*App, 
 	if options == nil {
 		options = &LookupOptions{}
 	}
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	creationType := pb.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
 	if options.CreateIfMissing {

--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -76,7 +77,7 @@ var client pb.ModalClientClient
 
 func init() {
 	defaultConfig, _ = readConfigFile()
-	defaultProfile = getProfile("")
+	defaultProfile = getProfile(os.Getenv("MODAL_PROFILE"))
 	if err := updateClient(defaultProfile); err != nil {
 		panic(fmt.Sprintf("failed to initialize Modal client at startup: %v", err))
 	}

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -27,7 +27,12 @@ func ClsLookup(ctx context.Context, appName string, name string, options *Lookup
 	if options == nil {
 		options = &LookupOptions{}
 	}
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	cls := Cls{
 		methodNames: []string{},
 		ctx:         ctx,

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -129,6 +129,6 @@ func InitializeClient(options ClientOptions) error {
 	mergedProfile := defaultProfile
 	mergedProfile.TokenId = options.TokenId
 	mergedProfile.TokenSecret = options.TokenSecret
-	mergedProfile.Environment = firstNonEmpty(mergedProfile.Environment, options.Environment)
+	mergedProfile.Environment = firstNonEmpty(options.Environment, mergedProfile.Environment)
 	return updateClient(mergedProfile)
 }

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -100,28 +100,9 @@ func firstNonEmpty(values ...string) string {
 }
 
 func environmentName(environment string) string {
-	return firstNonEmpty(environment, defaultProfile.Environment)
+	return firstNonEmpty(environment, clientProfile.Environment)
 }
 
 func imageBuilderVersion(version string) string {
-	return firstNonEmpty(version, defaultProfile.ImageBuilderVersion, "2024.10")
-}
-
-// ClientOptions defines credentials and options for initializing the Modal client at runtime.
-type ClientOptions struct {
-	TokenId     string
-	TokenSecret string
-	Environment string // optional, defaults to the profile's environment
-}
-
-// InitializeClient updates the global Modal client configuration with the provided options.
-//
-// This function is useful when you want to set the client options programmatically. It
-// should be called once at the start of your application.
-func InitializeClient(options ClientOptions) error {
-	mergedProfile := defaultProfile
-	mergedProfile.TokenId = options.TokenId
-	mergedProfile.TokenSecret = options.TokenSecret
-	mergedProfile.Environment = firstNonEmpty(options.Environment, mergedProfile.Environment)
-	return updateClient(mergedProfile)
+	return firstNonEmpty(version, clientProfile.ImageBuilderVersion, "2024.10")
 }

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -55,20 +55,11 @@ func readConfigFile() (config, error) {
 	return cfg, nil
 }
 
-// getProfile resolves a profile by name.  Pass an empty string to follow the
-// same precedence as the TypeScript original:
-//
-//  1. MODAL_PROFILE env var
-//  2. first profile in the file with active = true
+// getProfile resolves a profile by name. Pass an empty string to instead return
+// the first profile in the configuration file with `active = true`.
 //
 // Returned Profile is ready for use; error describes what is missing.
 func getProfile(name string) Profile {
-	// 1. explicit argument overrides everything
-	if name == "" {
-		name = os.Getenv("MODAL_PROFILE")
-	}
-
-	// 2. look for `active = true` if still unspecified
 	if name == "" {
 		for n, p := range defaultConfig {
 			if p.Active {
@@ -78,10 +69,12 @@ func getProfile(name string) Profile {
 		}
 	}
 
-	// 3. get profile name in the configuration (if it exists)
-	raw := defaultConfig[name]
+	var raw rawProfile
+	if name != "" {
+		raw = defaultConfig[name]
+	}
 
-	// 4. env-vars override file values
+	// Env-vars override file values.
 	serverURL := firstNonEmpty(os.Getenv("MODAL_SERVER_URL"), raw.ServerURL, "https://api.modal.com:443")
 	tokenId := firstNonEmpty(os.Getenv("MODAL_TOKEN_ID"), raw.TokenId)
 	tokenSecret := firstNonEmpty(os.Getenv("MODAL_TOKEN_SECRET"), raw.TokenSecret)

--- a/modal-go/examples/init-client/main.go
+++ b/modal-go/examples/init-client/main.go
@@ -1,0 +1,35 @@
+// This example configures a client using a `CUSTOM_MODAL_ID` and `CUSTOM_MODAL_SECRET` environment variable.
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/modal-labs/libmodal/modal-go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	modal_id := os.Getenv("CUSTOM_MODAL_ID")
+	if modal_id == "" {
+		log.Fatal("CUSTOM_MODAL_ID environment variable not set")
+	}
+	modal_secret := os.Getenv("CUSTOM_MODAL_SECRET")
+	if modal_secret == "" {
+		log.Fatal("CUSTOM_MODAL_SECRET environment variable not set")
+	}
+
+	modal.InitializeClient(modal.ClientOptions{
+		TokenId:     modal_id,
+		TokenSecret: modal_secret,
+	})
+
+	echo, err := modal.FunctionLookup(ctx, "libmodal-test-support", "echo_string", nil)
+	if err != nil {
+		log.Fatalf("Failed to lookup function: %v", err)
+	}
+	log.Println(echo)
+}

--- a/modal-go/examples/init-client/main.go
+++ b/modal-go/examples/init-client/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -31,5 +32,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to lookup function: %v", err)
 	}
-	log.Println(echo)
+	fmt.Printf("%#v\n", echo)
 }

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -44,7 +44,11 @@ func FunctionLookup(ctx context.Context, appName string, name string, options *L
 	if options == nil {
 		options = &LookupOptions{}
 	}
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := client.FunctionGet(ctx, pb.FunctionGetRequest_builder{
 		AppName:         appName,

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -18,7 +18,11 @@ type FunctionCall struct {
 
 // FunctionCallFromId looks up a FunctionCall by ID.
 func FunctionCallFromId(ctx context.Context, functionCallId string) (*FunctionCall, error) {
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	functionCall := FunctionCall{
 		FunctionCallId: functionCallId,
 		ctx:            ctx,

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -69,7 +69,11 @@ func QueueEphemeral(ctx context.Context, options *EphemeralOptions) (*Queue, err
 	if options == nil {
 		options = &EphemeralOptions{}
 	}
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := client.QueueGetOrCreate(ctx, pb.QueueGetOrCreateRequest_builder{
 		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
@@ -117,7 +121,11 @@ func QueueLookup(ctx context.Context, name string, options *LookupOptions) (*Que
 	if options == nil {
 		options = &LookupOptions{}
 	}
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	creationType := pb.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
 	if options.CreateIfMissing {

--- a/modal-go/secret.go
+++ b/modal-go/secret.go
@@ -22,7 +22,11 @@ type SecretFromNameOptions struct {
 
 // SecretFromName references a modal.Secret by its name.
 func SecretFromName(ctx context.Context, name string, options *SecretFromNameOptions) (*Secret, error) {
-	ctx = clientContext(ctx)
+	var err error
+	ctx, err = clientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if options == nil {
 		options = &SecretFromNameOptions{}

--- a/modal-js/examples/init-client.ts
+++ b/modal-js/examples/init-client.ts
@@ -1,0 +1,17 @@
+// This example configures a client using a `CUSTOM_MODAL_ID` and `CUSTOM_MODAL_SECRET` environment variable.
+
+import { Function_, initializeClient } from "modal";
+
+const modalId = process.env.CUSTOM_MODAL_ID;
+if (!modalId) {
+    throw new Error("CUSTOM_MODAL_ID environment variable not set");
+}
+const modalSecret = process.env.CUSTOM_MODAL_SECRET;
+if (!modalSecret) {
+    throw new Error("CUSTOM_MODAL_SECRET environment variable not set");
+}
+
+initializeClient({tokenId: modalId, tokenSecret: modalSecret})
+
+const echo = await Function_.lookup("libmodal-test-support", "echo_string");
+console.log(echo)

--- a/modal-js/examples/init-client.ts
+++ b/modal-js/examples/init-client.ts
@@ -4,14 +4,14 @@ import { Function_, initializeClient } from "modal";
 
 const modalId = process.env.CUSTOM_MODAL_ID;
 if (!modalId) {
-    throw new Error("CUSTOM_MODAL_ID environment variable not set");
+  throw new Error("CUSTOM_MODAL_ID environment variable not set");
 }
 const modalSecret = process.env.CUSTOM_MODAL_SECRET;
 if (!modalSecret) {
-    throw new Error("CUSTOM_MODAL_SECRET environment variable not set");
+  throw new Error("CUSTOM_MODAL_SECRET environment variable not set");
 }
 
-initializeClient({tokenId: modalId, tokenSecret: modalSecret})
+initializeClient({ tokenId: modalId, tokenSecret: modalSecret });
 
 const echo = await Function_.lookup("libmodal-test-support", "echo_string");
-console.log(echo)
+console.log(echo);

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -14,33 +14,6 @@ import { ClientType, ModalClientDefinition } from "../proto/modal_proto/api";
 import { getProfile, type Profile } from "./config";
 
 const defaultProfile = getProfile(process.env["MODAL_PROFILE"]);
-export let clientProfile = defaultProfile;
-
-export let client = createClient(clientProfile);
-
-/** Options for initializing a client at runtime. */
-export type ClientOptions = {
-  tokenId: string;
-  tokenSecret: string;
-  environment?: string;
-};
-
-/**
- * Initialize the Modal client, passing in token authentication credentials.
- *
- * You should call this function at the start of your application if not
- * configuring Modal with a `.modal.toml` file or environment variables.
- */
-export function initializeClient(options: ClientOptions) {
-  const mergedProfile = {
-    ...defaultProfile,
-    tokenId: options.tokenId,
-    tokenSecret: options.tokenSecret,
-    environment: options.environment || defaultProfile.environment,
-  };
-  clientProfile = mergedProfile;
-  client = createClient(mergedProfile);
-}
 
 /** gRPC client middleware to add auth token to request. */
 function authMiddleware(profile: Profile): ClientMiddleware {
@@ -240,4 +213,32 @@ function createClient(profile: Profile) {
     .use(retryMiddleware)
     .use(timeoutMiddleware)
     .create(ModalClientDefinition, channel);
+}
+
+export let clientProfile = defaultProfile;
+
+export let client = createClient(clientProfile);
+
+/** Options for initializing a client at runtime. */
+export type ClientOptions = {
+  tokenId: string;
+  tokenSecret: string;
+  environment?: string;
+};
+
+/**
+ * Initialize the Modal client, passing in token authentication credentials.
+ *
+ * You should call this function at the start of your application if not
+ * configuring Modal with a `.modal.toml` file or environment variables.
+ */
+export function initializeClient(options: ClientOptions) {
+  const mergedProfile = {
+    ...defaultProfile,
+    tokenId: options.tokenId,
+    tokenSecret: options.tokenSecret,
+    environment: options.environment || defaultProfile.environment,
+  };
+  clientProfile = mergedProfile;
+  client = createClient(mergedProfile);
 }

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { parse as parseToml } from "smol-toml";
+import { updateClient } from "./client";
 
 /** Raw representation of the .modal.toml file. */
 interface Config {
@@ -18,8 +19,8 @@ interface Config {
 /** Resolved configuration object from `Config` and environment variables. */
 export interface Profile {
   serverUrl: string;
-  tokenId: string;
-  tokenSecret: string;
+  tokenId?: string;
+  tokenSecret?: string;
   environment?: string;
   imageBuilderVersion?: string;
 }
@@ -34,7 +35,9 @@ function readConfigFile(): Config {
     if (err.code === "ENOENT") {
       return {} as Config;
     }
-    throw new Error(`Failed to read or parse .modal.toml: ${err.message}`);
+    // Ignore failure to read or parse .modal.toml
+    // throw new Error(`Failed to read or parse .modal.toml: ${err.message}`);
+    return {} as Config;
   }
 }
 
@@ -46,7 +49,6 @@ function readConfigFile(): Config {
 const config: Config = readConfigFile();
 
 export function getProfile(profileName?: string): Profile {
-  profileName = profileName || process.env["MODAL_PROFILE"] || undefined;
   if (!profileName) {
     for (const [name, profileData] of Object.entries(config)) {
       if (profileData.active) {
@@ -55,12 +57,10 @@ export function getProfile(profileName?: string): Profile {
       }
     }
   }
-  if (profileName && !Object.hasOwn(config, profileName)) {
-    throw new Error(
-      `Profile "${profileName}" not found in .modal.toml. Please set the MODAL_PROFILE environment variable or specify a valid profile.`,
-    );
-  }
-  const profileData = profileName ? config[profileName] : {};
+  const profileData =
+    profileName && Object.hasOwn(config, profileName)
+      ? config[profileName]
+      : {};
 
   const profile: Partial<Profile> = {
     serverUrl:
@@ -74,11 +74,6 @@ export function getProfile(profileName?: string): Profile {
       process.env["MODAL_IMAGE_BUILDER_VERSION"] ||
       profileData.imageBuilderVersion,
   };
-  if (!profile.tokenId || !profile.tokenSecret) {
-    throw new Error(
-      `Profile "${profileName}" is missing token_id or token_secret. Please set them in .modal.toml or as environment variables.`,
-    );
-  }
   return profile as Profile; // safe to null-cast because of check above
 }
 
@@ -90,4 +85,27 @@ export function environmentName(environment?: string): string {
 
 export function imageBuilderVersion(version?: string): string {
   return version || profile.imageBuilderVersion || "2024.10";
+}
+
+/** Options for initializing a client at runtime. */
+export type ClientOptions = {
+  tokenId: string;
+  tokenSecret: string;
+  environment?: string;
+};
+
+/**
+ * Initialize the Modal client, passing in token authentication credentials.
+ *
+ * You should call this function at the start of your application if not
+ * configuring Modal with a `.modal.toml` file or environment variables.
+ */
+export function initializeClient(options: ClientOptions) {
+  const mergedProfile = {
+    ...profile,
+    tokenId: options.tokenId,
+    tokenSecret: options.tokenSecret,
+    environment: options.environment || profile.environment,
+  };
+  updateClient(mergedProfile);
 }

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { parse as parseToml } from "smol-toml";
-import { updateClient } from "./client";
+import { clientProfile } from "./client";
 
 /** Raw representation of the .modal.toml file. */
 interface Config {
@@ -77,35 +77,10 @@ export function getProfile(profileName?: string): Profile {
   return profile as Profile; // safe to null-cast because of check above
 }
 
-export const profile = getProfile(process.env["MODAL_PROFILE"]);
-
 export function environmentName(environment?: string): string {
-  return environment || profile.environment || "";
+  return environment || clientProfile.environment || "";
 }
 
 export function imageBuilderVersion(version?: string): string {
-  return version || profile.imageBuilderVersion || "2024.10";
-}
-
-/** Options for initializing a client at runtime. */
-export type ClientOptions = {
-  tokenId: string;
-  tokenSecret: string;
-  environment?: string;
-};
-
-/**
- * Initialize the Modal client, passing in token authentication credentials.
- *
- * You should call this function at the start of your application if not
- * configuring Modal with a `.modal.toml` file or environment variables.
- */
-export function initializeClient(options: ClientOptions) {
-  const mergedProfile = {
-    ...profile,
-    tokenId: options.tokenId,
-    tokenSecret: options.tokenSecret,
-    environment: options.environment || profile.environment,
-  };
-  updateClient(mergedProfile);
+  return version || clientProfile.imageBuilderVersion || "2024.10";
 }

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -77,7 +77,7 @@ export function getProfile(profileName?: string): Profile {
   return profile as Profile; // safe to null-cast because of check above
 }
 
-export const profile = getProfile(process.env["MODAL_PROFILE"] || undefined);
+export const profile = getProfile(process.env["MODAL_PROFILE"]);
 
 export function environmentName(environment?: string): string {
   return environment || profile.environment || "";

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -5,8 +5,8 @@ export {
   type LookupOptions,
   type SandboxCreateOptions,
 } from "./app";
+export { type ClientOptions, initializeClient } from "./client";
 export { Cls, ClsInstance } from "./cls";
-export { type ClientOptions, initializeClient } from "./config";
 export {
   FunctionTimeoutError,
   RemoteError,

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -6,6 +6,7 @@ export {
   type SandboxCreateOptions,
 } from "./app";
 export { Cls, ClsInstance } from "./cls";
+export { type ClientOptions, initializeClient } from "./config";
 export {
   FunctionTimeoutError,
   RemoteError,


### PR DESCRIPTION
This allows you to run:

```ts
import { initializeClient } from "modal";

initializeClient({
  tokenId: "ak-123123456",
  tokenSecret: "as-123123123",
});
```

After startup and before calling any Modal APIs.