### PR TITLE
Allow access to the internal client

### DIFF
--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -282,4 +282,6 @@ export function initializeClient(options: ClientOptions) {
   };
   clientProfile = mergedProfile;
   client = createClient(mergedProfile);
+
+  return client;
 }


### PR DESCRIPTION
To allow calls with advanced options like this:

```ts
const client = initializeClient({
  tokenId: "ak-XYZ",
  tokenSecret: "as-XYZ",
});

const sb = await client.sandboxCreate({
  appId: app.appId,
  definition: {
    // ... some advanced configuration
  },
});

const sandbox = new Sandbox(sb.sandboxId);

// do something with the wrapper

```