### PR TITLE
Release modal-js/v0.3.16, modal-go/v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
+No unreleased changes.
+
+## modal-js/v0.3.16, modal-go/v0.0.16
+
 - Added support for getting Sandboxes from an ID.
 
 ## modal-js/v0.3.15, modal-go/v0.0.15

--- a/modal-js/package-lock.json
+++ b/modal-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modal",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modal",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "license": "Apache-2.0",
       "dependencies": {
         "long": "^5.3.1",

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modal",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Modal client library for JavaScript",
   "license": "Apache-2.0",
   "homepage": "https://modal.com/docs",


### PR DESCRIPTION
Release modal-js/v0.3.16, modal-go/v0.0.16, by running `python ci/release.py version patch`

Due to branch protection, this needs to be done in a PR.