### PR TITLE
Get go version from the changelog

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -109,7 +109,7 @@ def update_version(args):
 
     run_cli(["git", "diff"])
     run_cli(["git", "add", str(changelog_path)])
-    run_cli(["git", "commit", "-m", f"Update changelog for {version_header}"])
+    run_cli(["git", "commit", "-m", f"Prepare release for {version_header}"])
 
 
 def publish(args):


### PR DESCRIPTION
There was a bug in the publish script where the go release's tag did not update.

With this PR, the changelog becomes the source of truth for the go version to publish.