### PR TITLE
Adds github workflow to automate release PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,15 +19,15 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         submodules: true
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.13'
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
         cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
 
     - name: Create Pull Request
       id: cpr
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
       with:
         title: ${{ env.PR_TITLE }}
         body: ${{ env.PR_TITLE }}


### PR DESCRIPTION
I tested this on my fork: https://github.com/thomasjpfan/libmodal/pull/4

The trigger is using UI:

![Screenshot 2025-08-12 at 1 32 29 PM](https://github.com/user-attachments/assets/43eab581-e9a1-4228-8757-a96628bbc1aa)

You can also use the github CLI with: `gh workflow run ...`