### PR TITLE
Add publish release workflow to trigger on message

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,20 +8,20 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
-    if: startsWith(github.event.head_commit.message, 'Prepare release for')
+    if: startsWith(github.event.head_commit.message, '[RELEASE] Prepare release for')
     permissions:
       contents: write
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         submodules: true
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.13'
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: "20.x"
         cache: 'npm'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,44 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    if: startsWith(github.event.head_commit.message, 'Prepare release for')
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        submodules: true
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20.x"
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+        cache-dependency-path: modal-js/package-lock.json
+
+    - name: Install npm packages
+      run: npm install
+      working-directory: ./modal-js
+
+    - name: Config git user
+      run: |
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+    - name: Publish and push tags
+      run: |
+        python ci/release.py publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ci/release.py
+++ b/ci/release.py
@@ -109,7 +109,7 @@ def update_version(args):
 
     run_cli(["git", "diff"])
     run_cli(["git", "add", str(changelog_path)])
-    run_cli(["git", "commit", "-m", f"Prepare release for {version_header}"])
+    run_cli(["git", "commit", "-m", f"[RELEASE] Prepare release for {version_header}"])
 
 
 def publish(args):


### PR DESCRIPTION
This together with https://github.com/modal-labs/libmodal/pull/80 will automate the release process. This PR adds a workflow that triggers publish when the commit message starts with "Prepare release for" which is created by https://github.com/modal-labs/libmodal/pull/80

With this PR, the release workflow becomes:

1. Trigger workflow from https://github.com/modal-labs/libmodal/pull/80 which opens a PR
2. One of us merges the PR
3. This PR's workflow runs to publish

---

For this PR to work, we also need to add a `NPM_TOKEN` sercret to auth with the npm registry.