### PR TITLE
Reduce Sandbox.wait timeouts to same as Python client

### DIFF
--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -202,7 +202,7 @@ func (sb *Sandbox) Wait() (int, error) {
 	for {
 		resp, err := client.SandboxWait(sb.ctx, pb.SandboxWaitRequest_builder{
 			SandboxId: sb.SandboxId,
-			Timeout:   55,
+			Timeout:   10,
 		}.Build())
 		if err != nil {
 			return 0, err

--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -220,7 +220,7 @@ export class Sandbox {
     while (true) {
       const resp = await client.sandboxWait({
         sandboxId: this.sandboxId,
-        timeout: 55,
+        timeout: 10,
       });
       if (resp.result) {
         return Sandbox.#getReturnCode(resp.result)!;


### PR DESCRIPTION
I think this will fix the flaky JS tests, but not the underlying problem, which I suspect is server-side. But this makes the libmodal SDKs behave the same as Python so still valid to change I think.