### PR TITLE
Fix test imports

### DIFF
--- a/modal-js/test/cloud_bucket_mount.test.ts
+++ b/modal-js/test/cloud_bucket_mount.test.ts
@@ -1,9 +1,8 @@
+import { CloudBucketMount, Secret } from "modal";
 import {
-  CloudBucketMount,
   cloudBucketMountToProto,
   endpointUrlToBucketType,
 } from "../src/cloud_bucket_mount";
-import { Secret } from "../src/secret";
 import { CloudBucketMount_BucketType } from "../proto/modal_proto/api";
 import { expect, test } from "vitest";
 

--- a/modal-js/vitest.config.ts
+++ b/modal-js/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
   test: {
@@ -6,5 +7,10 @@ export default defineConfig({
     slowTestThreshold: 5_000,
     testTimeout: 20_000,
     reporters: ["verbose"],
+  },
+  resolve: {
+    alias: {
+      modal: path.resolve(__dirname, "./src/index.ts"),
+    },
   },
 });


### PR DESCRIPTION
Without this alias, vitest will not pick up on src changes without `npm run build`.