### PR TITLE
Upgrade upload-pages-artifact GHA

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload docs artifact
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./modal-js/docs
 


### PR DESCRIPTION
They [recently pinned the `upload-artifact` sub-dependency to a full SHA](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0).