### PR TITLE
Curl proxy.golang to make sure it picks up the update

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -122,10 +122,8 @@ def publish(args):
 
     run_cli(["git", "tag", f"modal-go/{go_version_str}"])
     run_cli(["git", "push", "--tags"])
-    run_cli(
-        ["go", "list", "-m", f"github.com/modal-labs/libmodal/modal-go@{go_version_str}"],
-        env={"GOPROXY": "proxy.golang.org"},
-    )
+
+    run_cli(["curl", f"https://proxy.golang.org/github.com/modal-labs/libmodal/modal-go/@v/{go_version_str}.info"])
 
 
 def main():


### PR DESCRIPTION
I had to `curl https://proxy.golang.org` to make sure the docs in https://pkg.go.dev/github.com/modal-labs/libmodal/modal-go gets updated.