### PR TITLE
Adds Image.FromID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
-No unreleased changes.
+- Adds `Image.fromId` (JS) / `NewImageFromId` (Go).
 
 ## modal-js/v0.3.17, modal-go/v0.0.17
 

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -66,6 +66,11 @@ func NewImageFromGcpArtifactRegistry(tag string, secret *Secret) *Image {
 	}
 }
 
+// NewImageFromId creates an Image from an ID
+func NewImageFromId(imageId string) *Image {
+	return &Image{ImageId: imageId}
+}
+
 func (image *Image) build(app *App) (*Image, error) {
 	if image == nil {
 		return nil, InvalidError{"image must be non-nil"}

--- a/modal-go/test/image_test.go
+++ b/modal-go/test/image_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/onsi/gomega"
 )
 
+func TestImageFromId(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	imageId := "im-23134214dfasfsaf"
+	image := modal.NewImageFromId(imageId)
+	g.Expect(image.ImageId).Should(gomega.Equal(imageId))
+}
+
 //nolint:staticcheck
 func TestImageFromRegistry(t *testing.T) {
 	t.Parallel()

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -30,6 +30,15 @@ export class Image {
   }
 
   /**
+   * Creates an `Image` instance from an image id
+   *
+   * @param imageId - Image id.
+   */
+  static fromId(imageID: string): Image {
+    return new Image(imageID, "");
+  }
+
+  /**
    * Creates an `Image` instance from a raw registry tag, optionally using a secret for authentication.
    *
    * @param tag - The registry tag for the image.

--- a/modal-js/test/image.test.ts
+++ b/modal-js/test/image.test.ts
@@ -1,6 +1,15 @@
 import { App, Secret, Image } from "modal";
 import { expect, test } from "vitest";
 
+test("ImageFromId", async () => {
+  const app = await App.lookup("libmodal-test", { createIfMissing: true });
+  expect(app.appId).toBeTruthy();
+
+  const imageId = "im-23134214dfasfsaf";
+  const image = await Image.fromId(imageId);
+  expect(image.imageId).toBe(imageId);
+});
+
 test("ImageFromRegistry", async () => {
   const app = await App.lookup("libmodal-test", { createIfMissing: true });
   expect(app.appId).toBeTruthy();


### PR DESCRIPTION
This PR adds constructors for image from ids. Together with https://github.com/modal-labs/libmodal/pull/103, one can now reference images from their ids.