### PR TITLE
Use us-west in tests

### DIFF
--- a/test-support/libmodal_test_support.py
+++ b/test-support/libmodal_test_support.py
@@ -32,7 +32,7 @@ class EchoCls:
         return "output: " + s
 
 
-@app.cls(min_containers=1, experimental_options={"input_plane_region": "us-east"})
+@app.cls(min_containers=1, experimental_options={"input_plane_region": "us-west"})
 class EchoClsInputPlane:
     @modal.method()
     def echo_string(self, s: str) -> str:


### PR DESCRIPTION
The us-east input plane is not available right now while we move it to a different cluster. This broke the libmodal tests (sorry!). For now we can just point the test at us-west.