### PR TITLE
Allow ci-release to run the ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci-release
   pull_request:
 
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci-release
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Currently, the PR from the release pipeline needs to be closed and reopened to run: https://github.com/modal-labs/libmodal/pull/112

I think if we specify the `ci-release` branch it should run.