### PR TITLE
Use a Github app to open release pr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,12 @@ jobs:
       run: npm install
       working-directory: ./modal-js
 
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+      with:
+        app-id: ${{ vars.RELEASE_APP_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
     - name: Config git user
       run: |
@@ -54,5 +60,5 @@ jobs:
         PR_TITLE="$(git log -1 --pretty=%B)"
         gh pr create --title "$PR_TITLE" --body "$PR_TITLE" --base main --head ci-release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 


### PR DESCRIPTION
According to https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow, we can use a Github App to open a workflow from another workflow to trigger the CI in the PR.