### PR TITLE
Rename `...Options` structs to `...Params`

### DIFF
--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -48,26 +48,26 @@ func parseGPUConfig(gpu string) (*pb.GPUConfig, error) {
 	}.Build(), nil
 }
 
-// AppFromNameOptions are options for client.Apps.FromName.
-type AppFromNameOptions struct {
+// AppFromNameParams are options for client.Apps.FromName.
+type AppFromNameParams struct {
 	Environment     string
 	CreateIfMissing bool
 }
 
 // FromName references an App with a given name, creating a new App if necessary.
-func (s *AppService) FromName(ctx context.Context, name string, options *AppFromNameOptions) (*App, error) {
-	if options == nil {
-		options = &AppFromNameOptions{}
+func (s *AppService) FromName(ctx context.Context, name string, params *AppFromNameParams) (*App, error) {
+	if params == nil {
+		params = &AppFromNameParams{}
 	}
 
 	creationType := pb.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
-	if options.CreateIfMissing {
+	if params.CreateIfMissing {
 		creationType = pb.ObjectCreationType_OBJECT_CREATION_TYPE_CREATE_IF_MISSING
 	}
 
 	resp, err := s.client.cpClient.AppGetOrCreate(ctx, pb.AppGetOrCreateRequest_builder{
 		AppName:            name,
-		EnvironmentName:    environmentName(options.Environment, s.client.profile),
+		EnvironmentName:    environmentName(params.Environment, s.client.profile),
 		ObjectCreationType: creationType,
 	}.Build())
 

--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -48,11 +48,11 @@ type Client struct {
 
 // NewClient generates a new client with the default profile configuration read from environment variables and ~/.modal.toml.
 func NewClient() (*Client, error) {
-	return NewClientWithOptions(ClientOptions{})
+	return NewClientWithOptions(ClientParams{})
 }
 
-// ClientOptions defines credentials and options for initializing the Modal client.
-type ClientOptions struct {
+// ClientParams defines credentials and options for initializing the Modal client.
+type ClientParams struct {
 	TokenId            string
 	TokenSecret        string
 	Environment        string
@@ -61,10 +61,10 @@ type ClientOptions struct {
 }
 
 // NewClientWithOptions generates a new client and allows overriding options in the default profile configuration.
-func NewClientWithOptions(options ClientOptions) (*Client, error) {
+func NewClientWithOptions(params ClientParams) (*Client, error) {
 	var cfg config
-	if options.Config != nil {
-		cfg = *options.Config
+	if params.Config != nil {
+		cfg = *params.Config
 	} else {
 		var err error
 		cfg, err = readConfigFile()
@@ -75,14 +75,14 @@ func NewClientWithOptions(options ClientOptions) (*Client, error) {
 
 	profile := getProfile(os.Getenv("MODAL_PROFILE"), cfg)
 
-	if options.TokenId != "" {
-		profile.TokenId = options.TokenId
+	if params.TokenId != "" {
+		profile.TokenId = params.TokenId
 	}
-	if options.TokenSecret != "" {
-		profile.TokenSecret = options.TokenSecret
+	if params.TokenSecret != "" {
+		profile.TokenSecret = params.TokenSecret
 	}
-	if options.Environment != "" {
-		profile.Environment = options.Environment
+	if params.Environment != "" {
+		profile.Environment = params.Environment
 	}
 
 	c := &Client{
@@ -92,8 +92,8 @@ func NewClientWithOptions(options ClientOptions) (*Client, error) {
 	}
 
 	var err error
-	if options.ControlPlaneClient != nil {
-		c.cpClient = options.ControlPlaneClient
+	if params.ControlPlaneClient != nil {
+		c.cpClient = params.ControlPlaneClient
 	} else {
 		_, c.cpClient, err = newClient(profile, c)
 	}

--- a/modal-go/cloud_bucket_mount.go
+++ b/modal-go/cloud_bucket_mount.go
@@ -22,8 +22,8 @@ type CloudBucketMount struct {
 	OidcAuthRoleArn   *string
 }
 
-// CloudBucketMountOptions are options for creating a CloudBucketMount.
-type CloudBucketMountOptions struct {
+// CloudBucketMountParams are options for creating a CloudBucketMount.
+type CloudBucketMountParams struct {
 	Secret            *Secret
 	ReadOnly          bool
 	RequesterPays     bool
@@ -33,19 +33,19 @@ type CloudBucketMountOptions struct {
 }
 
 // New creates a new CloudBucketMount.
-func (s *CloudBucketMountService) New(bucketName string, options *CloudBucketMountOptions) (*CloudBucketMount, error) {
-	if options == nil {
-		options = &CloudBucketMountOptions{}
+func (s *CloudBucketMountService) New(bucketName string, params *CloudBucketMountParams) (*CloudBucketMount, error) {
+	if params == nil {
+		params = &CloudBucketMountParams{}
 	}
 
 	mount := &CloudBucketMount{
 		BucketName:        bucketName,
-		Secret:            options.Secret,
-		ReadOnly:          options.ReadOnly,
-		RequesterPays:     options.RequesterPays,
-		BucketEndpointUrl: options.BucketEndpointUrl,
-		KeyPrefix:         options.KeyPrefix,
-		OidcAuthRoleArn:   options.OidcAuthRoleArn,
+		Secret:            params.Secret,
+		ReadOnly:          params.ReadOnly,
+		RequesterPays:     params.RequesterPays,
+		BucketEndpointUrl: params.BucketEndpointUrl,
+		KeyPrefix:         params.KeyPrefix,
+		OidcAuthRoleArn:   params.OidcAuthRoleArn,
 	}
 
 	if mount.BucketEndpointUrl != nil {

--- a/modal-go/cloud_bucket_mount_test.go
+++ b/modal-go/cloud_bucket_mount_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func newTestMount(bucketName string, options *CloudBucketMountOptions) (*CloudBucketMount, error) {
-	return (&CloudBucketMountService{}).New(bucketName, options)
+func newTestMount(bucketName string, params *CloudBucketMountParams) (*CloudBucketMount, error) {
+	return (&CloudBucketMountService{}).New(bucketName, params)
 }
 
 func TestNewCloudBucketMount_MinimalOptions(t *testing.T) {
@@ -39,7 +39,7 @@ func TestNewCloudBucketMount_AllOptions(t *testing.T) {
 	keyPrefix := "prefix/"
 	oidcRole := "arn:aws:iam::123456789:role/MyRole"
 
-	mount, err := newTestMount("my-bucket", &CloudBucketMountOptions{
+	mount, err := newTestMount("my-bucket", &CloudBucketMountParams{
 		Secret:            mockSecret,
 		ReadOnly:          true,
 		RequesterPays:     true,
@@ -98,12 +98,12 @@ func TestGetBucketTypeFromEndpointURL(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
 
-			options := &CloudBucketMountOptions{}
+			params := &CloudBucketMountParams{}
 			if tc.endpointURL != "" {
-				options.BucketEndpointUrl = &tc.endpointURL
+				params.BucketEndpointUrl = &tc.endpointURL
 			}
 
-			mount, err := newTestMount("my-bucket", options)
+			mount, err := newTestMount("my-bucket", params)
 			g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 			bucketType, err := getBucketTypeFromEndpointURL(mount.BucketEndpointUrl)
@@ -128,7 +128,7 @@ func TestNewCloudBucketMount_ValidationRequesterPaysWithoutSecret(t *testing.T) 
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	_, err := newTestMount("my-bucket", &CloudBucketMountOptions{
+	_, err := newTestMount("my-bucket", &CloudBucketMountParams{
 		RequesterPays: true,
 	})
 
@@ -140,7 +140,7 @@ func TestNewCloudBucketMount_ValidationKeyPrefixWithoutTrailingSlash(t *testing.
 	g := gomega.NewWithT(t)
 
 	keyPrefix := "prefix"
-	_, err := newTestMount("my-bucket", &CloudBucketMountOptions{
+	_, err := newTestMount("my-bucket", &CloudBucketMountParams{
 		KeyPrefix: &keyPrefix,
 	})
 
@@ -177,7 +177,7 @@ func TestCloudBucketMount_ToProtoAllOptions(t *testing.T) {
 	keyPrefix := "prefix/"
 	oidcRole := "arn:aws:iam::123456789:role/MyRole"
 
-	mount, err := newTestMount("my-bucket", &CloudBucketMountOptions{
+	mount, err := newTestMount("my-bucket", &CloudBucketMountParams{
 		Secret:            mockSecret,
 		ReadOnly:          true,
 		RequesterPays:     true,

--- a/modal-go/cls_test.go
+++ b/modal-go/cls_test.go
@@ -22,16 +22,16 @@ func TestBuildFunctionOptionsProto_MergesEnvAndSecrets(t *testing.T) {
 	envVars := map[string]string{"B": "2"}
 	envSecret := &Secret{SecretId: "test-env-secret"}
 
-	_, err := buildFunctionOptionsProto(&serviceOptions{env: &envVars}, nil)
+	_, err := buildFunctionOptionsProto(&serviceParams{env: &envVars}, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: env and envSecret must both be provided or neither be provided"))
 
-	mem := 1 // need to pass a non-empty serviceOptions to pass the !hasOptions(opts) check
-	_, err = buildFunctionOptionsProto(&serviceOptions{memory: &mem}, envSecret)
+	mem := 1 // need to pass a non-empty serviceOptions to pass the !hasParams() check
+	_, err = buildFunctionOptionsProto(&serviceParams{memory: &mem}, envSecret)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: env and envSecret must both be provided or neither be provided"))
 
-	functionOptions, err := buildFunctionOptionsProto(&serviceOptions{
+	functionOptions, err := buildFunctionOptionsProto(&serviceParams{
 		env:     &envVars,
 		secrets: &[]*Secret{secret},
 	}, envSecret)
@@ -49,7 +49,7 @@ func TestBuildFunctionOptionsProto_WithOnlyEnvParameter(t *testing.T) {
 	envVars := map[string]string{"B": "2"}
 	envSecret := &Secret{SecretId: "test-env-secret"}
 
-	functionOptions, err := buildFunctionOptionsProto(&serviceOptions{
+	functionOptions, err := buildFunctionOptionsProto(&serviceParams{
 		env: &envVars,
 	}, envSecret)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -64,9 +64,9 @@ func TestBuildFunctionOptionsProto_EmptyEnv_WithSecrets(t *testing.T) {
 
 	secret := &Secret{SecretId: "test-secret-1"}
 
-	opts := &serviceOptions{env: &map[string]string{}, secrets: &[]*Secret{secret}}
+	params := &serviceParams{env: &map[string]string{}, secrets: &[]*Secret{secret}}
 
-	functionOptions, err := buildFunctionOptionsProto(opts, nil)
+	functionOptions, err := buildFunctionOptionsProto(params, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	g.Expect(functionOptions.GetSecretIds()).To(gomega.HaveLen(1))
@@ -77,7 +77,7 @@ func TestBuildFunctionOptionsProto_EmptyEnv_WithSecrets(t *testing.T) {
 func TestBuildFunctionOptionsProto_EmptyEnv_NoSecrets(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	functionOptions, err := buildFunctionOptionsProto(&serviceOptions{env: &map[string]string{}}, nil)
+	functionOptions, err := buildFunctionOptionsProto(&serviceParams{env: &map[string]string{}}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	g.Expect(functionOptions.GetSecretIds()).To(gomega.HaveLen(0))

--- a/modal-go/examples/cls-call-with-options/main.go
+++ b/modal-go/examples/cls-call-with-options/main.go
@@ -40,10 +40,10 @@ func main() {
 	}
 
 	instanceWithOptions, err := cls.
-		WithOptions(modal.ClsWithOptionsOptions{
+		WithOptions(modal.ClsWithOptionsParams{
 			Secrets: []*modal.Secret{secret},
 		}).
-		WithConcurrency(modal.ClsWithConcurrencyOptions{MaxInputs: 1}).
+		WithConcurrency(modal.ClsWithConcurrencyParams{MaxInputs: 1}).
 		Instance(ctx, nil)
 	if err != nil {
 		log.Fatalf("Failed to create Cls instance with options: %v", err)

--- a/modal-go/examples/image-building/main.go
+++ b/modal-go/examples/image-building/main.go
@@ -16,7 +16,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -29,12 +29,12 @@ func main() {
 	}
 
 	image := mc.Images.FromRegistry("alpine:3.21", nil).
-		DockerfileCommands([]string{"RUN apk add --no-cache curl=$CURL_VERSION"}, &modal.ImageDockerfileCommandsOptions{
+		DockerfileCommands([]string{"RUN apk add --no-cache curl=$CURL_VERSION"}, &modal.ImageDockerfileCommandsParams{
 			Secrets: []*modal.Secret{secret},
 		}).
 		DockerfileCommands([]string{"ENV SERVER=ipconfig.me"}, nil)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"sh", "-c", "curl -Ls $SERVER"},
 	})
 	if err != nil {

--- a/modal-go/examples/init-client/main.go
+++ b/modal-go/examples/init-client/main.go
@@ -23,7 +23,7 @@ func main() {
 		log.Fatal("CUSTOM_MODAL_SECRET environment variable not set")
 	}
 
-	mc, err := modal.NewClientWithOptions(modal.ClientOptions{
+	mc, err := modal.NewClientWithOptions(modal.ClientParams{
 		TokenId:     modal_id,
 		TokenSecret: modal_secret,
 	})

--- a/modal-go/examples/sandbox-agent/main.go
+++ b/modal-go/examples/sandbox-agent/main.go
@@ -16,7 +16,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -56,14 +56,14 @@ func main() {
 	}
 	fmt.Println("\nRunning command:", claudeCmd)
 
-	secret, err := mc.Secrets.FromName(ctx, "libmodal-anthropic-secret", &modal.SecretFromNameOptions{
+	secret, err := mc.Secrets.FromName(ctx, "libmodal-anthropic-secret", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"ANTHROPIC_API_KEY"},
 	})
 	if err != nil {
 		log.Fatalf("Failed to get secret: %v", err)
 	}
 
-	claude, err := sb.Exec(ctx, claudeCmd, &modal.SandboxExecOptions{
+	claude, err := sb.Exec(ctx, claudeCmd, &modal.SandboxExecParams{
 		PTY:     true, // Adding a PTY is important, since Claude requires it!
 		Secrets: []*modal.Secret{secret},
 		Workdir: "/repo",

--- a/modal-go/examples/sandbox-cloud-bucket/main.go
+++ b/modal-go/examples/sandbox-cloud-bucket/main.go
@@ -15,7 +15,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	keyPrefix := "data/"
-	cloudBucketMount, err := mc.CloudBucketMounts.New("my-s3-bucket", &modal.CloudBucketMountOptions{
+	cloudBucketMount, err := mc.CloudBucketMounts.New("my-s3-bucket", &modal.CloudBucketMountParams{
 		Secret:    secret,
 		KeyPrefix: &keyPrefix,
 		ReadOnly:  true,
@@ -37,7 +37,7 @@ func main() {
 		log.Fatalf("Failed to create Cloud Bucket Mount: %v", err)
 	}
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"sh", "-c", "ls -la /mnt/s3-bucket"},
 		CloudBucketMounts: map[string]*modal.CloudBucketMount{
 			"/mnt/s3-bucket": cloudBucketMount,

--- a/modal-go/examples/sandbox-exec/main.go
+++ b/modal-go/examples/sandbox-exec/main.go
@@ -15,7 +15,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -68,13 +68,13 @@ for i in range(50000):
 	}
 	log.Println("Return code:", returnCode)
 
-	secret, err := mc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameOptions{RequiredKeys: []string{"c"}})
+	secret, err := mc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameParams{RequiredKeys: []string{"c"}})
 	if err != nil {
 		log.Fatalf("Unable to get Secret: %v", err)
 	}
 
 	// Passing Secrets in a command
-	p, err = sb.Exec(ctx, []string{"printenv", "c"}, &modal.SandboxExecOptions{Secrets: []*modal.Secret{secret}})
+	p, err = sb.Exec(ctx, []string{"printenv", "c"}, &modal.SandboxExecParams{Secrets: []*modal.Secret{secret}})
 	if err != nil {
 		log.Fatalf("Faield to execute env command in Sandbox: %v", err)
 	}

--- a/modal-go/examples/sandbox-filesystem-snapshot/main.go
+++ b/modal-go/examples/sandbox-filesystem-snapshot/main.go
@@ -16,14 +16,14 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 
 	baseImage := mc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, baseImage, &modal.SandboxCreateOptions{})
+	sb, err := mc.Sandboxes.Create(ctx, app, baseImage, &modal.SandboxCreateParams{})
 	if err != nil {
 		log.Fatalf("Failed to create Sandbox: %v", err)
 	}

--- a/modal-go/examples/sandbox-filesystem/main.go
+++ b/modal-go/examples/sandbox-filesystem/main.go
@@ -16,14 +16,14 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 
 	image := mc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{})
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{})
 	if err != nil {
 		log.Fatalf("Failed to create Sandbox: %v", err)
 	}

--- a/modal-go/examples/sandbox-gpu/main.go
+++ b/modal-go/examples/sandbox-gpu/main.go
@@ -15,14 +15,14 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 
 	image := mc.Images.FromRegistry("nvidia/cuda:12.4.0-devel-ubuntu22.04", nil)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		GPU: "A10G",
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-named/main.go
+++ b/modal-go/examples/sandbox-named/main.go
@@ -16,7 +16,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -25,7 +25,7 @@ func main() {
 
 	sandboxName := "libmodal-example-named-sandbox"
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Name:    sandboxName,
 		Command: []string{"cat"},
 	})
@@ -41,7 +41,7 @@ func main() {
 	fmt.Printf("Created Sandbox with name: %s\n", sandboxName)
 	fmt.Printf("Sandbox ID: %s\n", sb.SandboxId)
 
-	_, err = mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Name:    sandboxName,
 		Command: []string{"cat"},
 	})

--- a/modal-go/examples/sandbox-poll/main.go
+++ b/modal-go/examples/sandbox-poll/main.go
@@ -15,7 +15,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -23,7 +23,7 @@ func main() {
 	image := mc.Images.FromRegistry("alpine:3.21", nil)
 
 	// Create a sandbox that waits for input, then exits with code 42
-	sandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"sh", "-c", "read line; exit 42"},
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-prewarm/main.go
+++ b/modal-go/examples/sandbox-prewarm/main.go
@@ -17,7 +17,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -37,7 +37,7 @@ func main() {
 		log.Fatalf("Unable to look up Image from ID: %v", err)
 	}
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image2, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image2, &modal.SandboxCreateParams{
 		Command: []string{"cat"},
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-private-image/main.go
+++ b/modal-go/examples/sandbox-private-image/main.go
@@ -15,12 +15,12 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 
-	secret, err := mc.Secrets.FromName(ctx, "libmodal-aws-ecr-test", &modal.SecretFromNameOptions{
+	secret, err := mc.Secrets.FromName(ctx, "libmodal-aws-ecr-test", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
 	})
 	if err != nil {
@@ -29,7 +29,7 @@ func main() {
 
 	image := mc.Images.FromAwsEcr("459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python", secret)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"python", "-c", `import sys; sys.stdout.write(sys.stdin.read())`},
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-proxy/main.go
+++ b/modal-go/examples/sandbox-proxy/main.go
@@ -15,7 +15,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -28,7 +28,7 @@ func main() {
 	}
 	log.Printf("Using Proxy: %s", proxy.ProxyId)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Proxy: proxy,
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-secrets/main.go
+++ b/modal-go/examples/sandbox-secrets/main.go
@@ -15,13 +15,13 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 	image := mc.Images.FromRegistry("alpine:3.21", nil)
 
-	secret, err := mc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameOptions{RequiredKeys: []string{"c"}})
+	secret, err := mc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameParams{RequiredKeys: []string{"c"}})
 	if err != nil {
 		log.Fatalf("Failed finding a Secret: %v", err)
 	}
@@ -33,7 +33,7 @@ func main() {
 		log.Fatalf("Failed creating ephemeral Secret: %v", err)
 	}
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"sh", "-lc", "printenv | grep -E '^c|d='"}, Secrets: []*modal.Secret{secret, ephemeralSecret},
 	})
 	if err != nil {

--- a/modal-go/examples/sandbox-tunnels/main.go
+++ b/modal-go/examples/sandbox-tunnels/main.go
@@ -18,7 +18,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -26,7 +26,7 @@ func main() {
 	// Create a Sandbox with Python's built-in HTTP server
 	image := mc.Images.FromRegistry("python:3.12-alpine", nil)
 
-	sandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command:        []string{"python3", "-m", "http.server", "8000"},
 		EncryptedPorts: []int{8000},
 		Timeout:        1 * time.Minute,

--- a/modal-go/examples/sandbox-volume-ephemeral/main.go
+++ b/modal-go/examples/sandbox-volume-ephemeral/main.go
@@ -16,7 +16,7 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
@@ -29,7 +29,7 @@ func main() {
 	}
 	defer volume.CloseEphemeral()
 
-	writerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	writerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{
 			"sh",
 			"-c",
@@ -59,7 +59,7 @@ func main() {
 		log.Fatalf("Failed to terminate Sandbox %s: %v", writerSandbox.SandboxId, err)
 	}
 
-	readerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	readerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"cat", "/mnt/volume/message.txt"},
 		Volumes: map[string]*modal.Volume{
 			"/mnt/volume": volume.ReadOnly(),

--- a/modal-go/examples/sandbox-volume/main.go
+++ b/modal-go/examples/sandbox-volume/main.go
@@ -16,21 +16,21 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 
 	image := mc.Images.FromRegistry("alpine:3.21", nil)
 
-	volume, err := mc.Volumes.FromName(ctx, "libmodal-example-volume", &modal.VolumeFromNameOptions{
+	volume, err := mc.Volumes.FromName(ctx, "libmodal-example-volume", &modal.VolumeFromNameParams{
 		CreateIfMissing: true,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create Volume: %v", err)
 	}
 
-	writerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	writerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{
 			"sh",
 			"-c",
@@ -56,7 +56,7 @@ func main() {
 	}
 	fmt.Printf("Writer finished with exit code: %d\n", exitCode)
 
-	readerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	readerSandbox, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Volumes: map[string]*modal.Volume{
 			"/mnt/volume": volume.ReadOnly(),
 		},

--- a/modal-go/examples/sandbox/main.go
+++ b/modal-go/examples/sandbox/main.go
@@ -15,14 +15,14 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := mc.Apps.FromName(ctx, "libmodal-example", &modal.AppFromNameParams{CreateIfMissing: true})
 	if err != nil {
 		log.Fatalf("Failed to get or create App: %v", err)
 	}
 
 	image := mc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"cat"},
 	})
 	if err != nil {

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -41,8 +41,8 @@ type FunctionStats struct {
 	NumTotalRunners int
 }
 
-// FunctionUpdateAutoscalerOptions contains options for overriding a Function's autoscaler behavior.
-type FunctionUpdateAutoscalerOptions struct {
+// FunctionUpdateAutoscalerParams contains options for overriding a Function's autoscaler behavior.
+type FunctionUpdateAutoscalerParams struct {
 	MinContainers    *uint32
 	MaxContainers    *uint32
 	BufferContainers *uint32
@@ -59,22 +59,22 @@ type Function struct {
 	client *Client
 }
 
-// FunctionFromNameOptions are options for client.Functions.FromName.
-type FunctionFromNameOptions struct {
+// FunctionFromNameParams are options for client.Functions.FromName.
+type FunctionFromNameParams struct {
 	Environment     string
 	CreateIfMissing bool
 }
 
 // FromName references a Function from a deployed App by its name.
-func (s *FunctionService) FromName(ctx context.Context, appName string, name string, options *FunctionFromNameOptions) (*Function, error) {
-	if options == nil {
-		options = &FunctionFromNameOptions{}
+func (s *FunctionService) FromName(ctx context.Context, appName string, name string, params *FunctionFromNameParams) (*Function, error) {
+	if params == nil {
+		params = &FunctionFromNameParams{}
 	}
 
 	resp, err := s.client.cpClient.FunctionGet(ctx, pb.FunctionGetRequest_builder{
 		AppName:         appName,
 		ObjectTag:       name,
-		EnvironmentName: environmentName(options.Environment, s.client.profile),
+		EnvironmentName: environmentName(params.Environment, s.client.profile),
 	}.Build())
 
 	if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
@@ -222,12 +222,12 @@ func (f *Function) GetCurrentStats(ctx context.Context) (*FunctionStats, error) 
 }
 
 // UpdateAutoscaler overrides the current autoscaler behavior for this Function.
-func (f *Function) UpdateAutoscaler(ctx context.Context, opts FunctionUpdateAutoscalerOptions) error {
+func (f *Function) UpdateAutoscaler(ctx context.Context, params FunctionUpdateAutoscalerParams) error {
 	settings := pb.AutoscalerSettings_builder{
-		MinContainers:    opts.MinContainers,
-		MaxContainers:    opts.MaxContainers,
-		BufferContainers: opts.BufferContainers,
-		ScaledownWindow:  opts.ScaledownWindow,
+		MinContainers:    params.MinContainers,
+		MaxContainers:    params.MaxContainers,
+		BufferContainers: params.BufferContainers,
+		ScaledownWindow:  params.ScaledownWindow,
 	}.Build()
 
 	_, err := f.client.cpClient.FunctionUpdateSchedulingParams(ctx, pb.FunctionUpdateSchedulingParamsRequest_builder{

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -29,8 +29,8 @@ func (s *FunctionCallService) FromId(ctx context.Context, functionCallId string)
 	return &functionCall, nil
 }
 
-// FunctionCallGetOptions are options for getting outputs from Function Calls.
-type FunctionCallGetOptions struct {
+// FunctionCallGetParams are options for getting outputs from Function Calls.
+type FunctionCallGetParams struct {
 	// Timeout specifies the maximum duration to wait for the output.
 	// If nil, no timeout is applied. If set to 0, it will check if the function
 	// call is already completed.
@@ -39,27 +39,27 @@ type FunctionCallGetOptions struct {
 
 // Get waits for the output of a FunctionCall.
 // If timeout > 0, the operation will be cancelled after the specified duration.
-func (fc *FunctionCall) Get(ctx context.Context, options *FunctionCallGetOptions) (any, error) {
-	if options == nil {
-		options = &FunctionCallGetOptions{}
+func (fc *FunctionCall) Get(ctx context.Context, params *FunctionCallGetParams) (any, error) {
+	if params == nil {
+		params = &FunctionCallGetParams{}
 	}
 	invocation := controlPlaneInvocationFromFunctionCallId(fc.client.cpClient, fc.FunctionCallId)
-	return invocation.awaitOutput(ctx, options.Timeout)
+	return invocation.awaitOutput(ctx, params.Timeout)
 }
 
-// FunctionCallCancelOptions are options for cancelling Function Calls.
-type FunctionCallCancelOptions struct {
+// FunctionCallCancelParams are options for cancelling Function Calls.
+type FunctionCallCancelParams struct {
 	TerminateContainers bool
 }
 
 // Cancel cancels a FunctionCall.
-func (fc *FunctionCall) Cancel(ctx context.Context, options *FunctionCallCancelOptions) error {
-	if options == nil {
-		options = &FunctionCallCancelOptions{}
+func (fc *FunctionCall) Cancel(ctx context.Context, params *FunctionCallCancelParams) error {
+	if params == nil {
+		params = &FunctionCallCancelParams{}
 	}
 	_, err := fc.client.cpClient.FunctionCallCancel(ctx, pb.FunctionCallCancelRequest_builder{
 		FunctionCallId:      fc.FunctionCallId,
-		TerminateContainers: options.TerminateContainers,
+		TerminateContainers: params.TerminateContainers,
 	}.Build())
 	if err != nil {
 		return fmt.Errorf("FunctionCallCancel failed: %w", err)

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -14,8 +14,8 @@ import (
 // ImageService provides Image related operations.
 type ImageService struct{ client *Client }
 
-// ImageDockerfileCommandsOptions are options for Image.DockerfileCommands().
-type ImageDockerfileCommandsOptions struct {
+// ImageDockerfileCommandsParams are options for Image.DockerfileCommands().
+type ImageDockerfileCommandsParams struct {
 	// Environment variables to set in the build environment.
 	Env map[string]string
 
@@ -49,21 +49,21 @@ type Image struct {
 	client *Client
 }
 
-// ImageFromRegistryOptions are options for creating an Image from a registry.
-type ImageFromRegistryOptions struct {
+// ImageFromRegistryParams are options for creating an Image from a registry.
+type ImageFromRegistryParams struct {
 	Secret *Secret // Secret for private registry authentication.
 }
 
 // FromRegistry builds a Modal Image from a public or private image registry without any changes.
-func (s *ImageService) FromRegistry(tag string, options *ImageFromRegistryOptions) *Image {
-	if options == nil {
-		options = &ImageFromRegistryOptions{}
+func (s *ImageService) FromRegistry(tag string, params *ImageFromRegistryParams) *Image {
+	if params == nil {
+		params = &ImageFromRegistryParams{}
 	}
 	var imageRegistryConfig *pb.ImageRegistryConfig
-	if options.Secret != nil {
+	if params.Secret != nil {
 		imageRegistryConfig = pb.ImageRegistryConfig_builder{
 			RegistryAuthType: pb.RegistryAuthType_REGISTRY_AUTH_TYPE_STATIC_CREDS,
-			SecretId:         options.Secret.SecretId,
+			SecretId:         params.Secret.SecretId,
 		}.Build()
 	}
 
@@ -133,21 +133,21 @@ func (s *ImageService) FromId(ctx context.Context, imageId string) (*Image, erro
 //
 // Each call creates a new Image layer that will be built sequentially.
 // The provided options apply only to this layer.
-func (image *Image) DockerfileCommands(commands []string, options *ImageDockerfileCommandsOptions) *Image {
+func (image *Image) DockerfileCommands(commands []string, params *ImageDockerfileCommandsParams) *Image {
 	if len(commands) == 0 {
 		return image
 	}
 
-	if options == nil {
-		options = &ImageDockerfileCommandsOptions{}
+	if params == nil {
+		params = &ImageDockerfileCommandsParams{}
 	}
 
 	newLayer := layer{
 		commands:   append([]string{}, commands...),
-		env:        options.Env,
-		secrets:    options.Secrets,
-		gpu:        options.GPU,
-		forceBuild: options.ForceBuild,
+		env:        params.Env,
+		secrets:    params.Secrets,
+		gpu:        params.GPU,
+		forceBuild: params.ForceBuild,
 	}
 
 	newLayers := append([]layer{}, image.layers...)
@@ -298,12 +298,12 @@ func (image *Image) Build(ctx context.Context, app *App) (*Image, error) {
 	return image, nil
 }
 
-// ImageDeleteOptions are options for deleting an Image.
-type ImageDeleteOptions struct {
+// ImageDeleteParams are options for deleting an Image.
+type ImageDeleteParams struct {
 }
 
 // Delete deletes an Image by ID. Warning: This removes an *entire Image*, and cannot be undone.
-func (s *ImageService) Delete(ctx context.Context, imageId string, options *ImageDeleteOptions) error {
+func (s *ImageService) Delete(ctx context.Context, imageId string, params *ImageDeleteParams) error {
 	image, err := s.FromId(ctx, imageId)
 	if err != nil {
 		return err

--- a/modal-go/proxy.go
+++ b/modal-go/proxy.go
@@ -17,20 +17,20 @@ type Proxy struct {
 	ProxyId string
 }
 
-// ProxyFromNameOptions are options for looking up a Modal Proxy.
-type ProxyFromNameOptions struct {
+// ProxyFromNameParams are options for looking up a Modal Proxy.
+type ProxyFromNameParams struct {
 	Environment string
 }
 
 // FromName references a modal.Proxy by its name.
-func (s *ProxyService) FromName(ctx context.Context, name string, options *ProxyFromNameOptions) (*Proxy, error) {
-	if options == nil {
-		options = &ProxyFromNameOptions{}
+func (s *ProxyService) FromName(ctx context.Context, name string, params *ProxyFromNameParams) (*Proxy, error) {
+	if params == nil {
+		params = &ProxyFromNameParams{}
 	}
 
 	resp, err := s.client.cpClient.ProxyGet(ctx, pb.ProxyGetRequest_builder{
 		Name:            name,
-		EnvironmentName: environmentName(options.Environment, s.client.profile),
+		EnvironmentName: environmentName(params.Environment, s.client.profile),
 	}.Build())
 
 	if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {

--- a/modal-go/retries.go
+++ b/modal-go/retries.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// RetriesOptions are options for creating a Retries policy.
-type RetriesOptions struct {
+// RetriesParams are options for creating a Retries policy.
+type RetriesParams struct {
 	BackoffCoefficient *float32       // Multiplier for exponential backoff. Defaults to 2.0.
 	InitialDelay       *time.Duration // Defaults to 1s.
 	MaxDelay           *time.Duration // Defaults to 60s.
@@ -21,20 +21,20 @@ type Retries struct {
 }
 
 // NewRetries creates a new Retries configuration.
-func NewRetries(maxRetries int, options *RetriesOptions) (*Retries, error) {
+func NewRetries(maxRetries int, params *RetriesParams) (*Retries, error) {
 	backoffCoefficient := float32(2.0)
 	initialDelay := 1 * time.Second
 	maxDelay := 60 * time.Second
 
-	if options != nil {
-		if options.BackoffCoefficient != nil {
-			backoffCoefficient = *options.BackoffCoefficient
+	if params != nil {
+		if params.BackoffCoefficient != nil {
+			backoffCoefficient = *params.BackoffCoefficient
 		}
-		if options.InitialDelay != nil {
-			initialDelay = *options.InitialDelay
+		if params.InitialDelay != nil {
+			initialDelay = *params.InitialDelay
 		}
-		if options.MaxDelay != nil {
-			maxDelay = *options.MaxDelay
+		if params.MaxDelay != nil {
+			maxDelay = *params.MaxDelay
 		}
 	}
 

--- a/modal-go/sandbox_test.go
+++ b/modal-go/sandbox_test.go
@@ -10,7 +10,7 @@ import (
 func TestSandboxCreateRequestProto_WithoutPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateOptions{}, nil)
+	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateParams{}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	definition := req.GetDefinition()
@@ -21,7 +21,7 @@ func TestSandboxCreateRequestProto_WithoutPTY(t *testing.T) {
 func TestSandboxCreateRequestProto_WithPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateOptions{
+	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateParams{
 		PTY: true,
 	}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -44,17 +44,17 @@ func TestSandboxCreateRequestProto_MergesEnvAndSecrets(t *testing.T) {
 	envVars := map[string]string{"B": "2"}
 	envSecret := &Secret{SecretId: "test-env-secret"}
 
-	_, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateOptions{
+	_, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{
 		Env: envVars,
 	}, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
 
-	_, err = buildSandboxCreateRequestProto("ap", "im", SandboxCreateOptions{}, envSecret)
+	_, err = buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{}, envSecret)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
 
-	req, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateOptions{
+	req, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{
 		Env:     envVars,
 		Secrets: []*Secret{secret},
 	}, envSecret)
@@ -72,7 +72,7 @@ func TestSandboxCreateRequestProto_WithOnlyEnvParameter(t *testing.T) {
 	envVars := map[string]string{"B": "2", "C": "3"}
 	envSecret := &Secret{SecretId: "test-env-secret"}
 
-	req, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateOptions{
+	req, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{
 		Env: envVars,
 	}, envSecret)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -84,7 +84,7 @@ func TestSandboxCreateRequestProto_WithOnlyEnvParameter(t *testing.T) {
 
 func TestContainerExecProto_WithoutPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
-	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecOptions{}, nil)
+	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecParams{}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	ptyInfo := req.GetPtyInfo()
@@ -93,7 +93,7 @@ func TestContainerExecProto_WithoutPTY(t *testing.T) {
 
 func TestContainerExecProto_WithPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
-	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecOptions{
+	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecParams{
 		PTY: true,
 	}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -117,17 +117,17 @@ func TestContainerExecRequestProto_MergesEnvAndSecrets(t *testing.T) {
 	envVars := map[string]string{"B": "2"}
 	envSecret := &Secret{SecretId: "test-env-secret"}
 
-	_, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecOptions{
+	_, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{
 		Env: envVars,
 	}, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
 
-	_, err = buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecOptions{}, envSecret)
+	_, err = buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{}, envSecret)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
 
-	req, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecOptions{
+	req, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{
 		Env:     envVars,
 		Secrets: []*Secret{secret},
 	}, envSecret)
@@ -144,7 +144,7 @@ func TestContainerExecRequestProto_WithOnlyEnvParameter(t *testing.T) {
 	envVars := map[string]string{"B": "2"}
 	envSecret := &Secret{SecretId: "test-env-secret"}
 
-	req, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecOptions{
+	req, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{
 		Env: envVars,
 	}, envSecret)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/modal-go/secret.go
+++ b/modal-go/secret.go
@@ -15,22 +15,22 @@ type Secret struct {
 	Name     string
 }
 
-// SecretFromNameOptions are options for finding Modal Secrets.
-type SecretFromNameOptions struct {
+// SecretFromNameParams are options for finding Modal Secrets.
+type SecretFromNameParams struct {
 	Environment  string
 	RequiredKeys []string
 }
 
 // FromName references a Secret by its name.
-func (s *SecretService) FromName(ctx context.Context, name string, options *SecretFromNameOptions) (*Secret, error) {
-	if options == nil {
-		options = &SecretFromNameOptions{}
+func (s *SecretService) FromName(ctx context.Context, name string, params *SecretFromNameParams) (*Secret, error) {
+	if params == nil {
+		params = &SecretFromNameParams{}
 	}
 
 	resp, err := s.client.cpClient.SecretGetOrCreate(ctx, pb.SecretGetOrCreateRequest_builder{
 		DeploymentName:  name,
-		EnvironmentName: environmentName(options.Environment, s.client.profile),
-		RequiredKeys:    options.RequiredKeys,
+		EnvironmentName: environmentName(params.Environment, s.client.profile),
+		RequiredKeys:    params.RequiredKeys,
 	}.Build())
 
 	if err != nil {
@@ -40,21 +40,21 @@ func (s *SecretService) FromName(ctx context.Context, name string, options *Secr
 	return &Secret{SecretId: resp.GetSecretId(), Name: name}, nil
 }
 
-// SecretFromMapOptions are options for creating a Secret from a key/value map.
-type SecretFromMapOptions struct {
+// SecretFromMapParams are options for creating a Secret from a key/value map.
+type SecretFromMapParams struct {
 	Environment string
 }
 
 // FromMap creates a Secret from a map of key-value pairs.
-func (s *SecretService) FromMap(ctx context.Context, keyValuePairs map[string]string, options *SecretFromMapOptions) (*Secret, error) {
-	if options == nil {
-		options = &SecretFromMapOptions{}
+func (s *SecretService) FromMap(ctx context.Context, keyValuePairs map[string]string, params *SecretFromMapParams) (*Secret, error) {
+	if params == nil {
+		params = &SecretFromMapParams{}
 	}
 
 	resp, err := s.client.cpClient.SecretGetOrCreate(ctx, pb.SecretGetOrCreateRequest_builder{
 		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
 		EnvDict:            keyValuePairs,
-		EnvironmentName:    environmentName(options.Environment, s.client.profile),
+		EnvironmentName:    environmentName(params.Environment, s.client.profile),
 	}.Build())
 	if err != nil {
 		return nil, err

--- a/modal-go/test/cls_with_options_test.go
+++ b/modal-go/test/cls_with_options_test.go
@@ -71,9 +71,9 @@ func TestClsWithOptionsStacking(t *testing.T) {
 	newTimeout := 60 * time.Second
 
 	optioned := cls.
-		WithOptions(modal.ClsWithOptionsOptions{Timeout: &timeout, CPU: &cpu}).
-		WithOptions(modal.ClsWithOptionsOptions{Timeout: &newTimeout, Memory: &memory, GPU: &gpu}).
-		WithOptions(modal.ClsWithOptionsOptions{Secrets: []*modal.Secret{secret}, Volumes: map[string]*modal.Volume{"/mnt/test": volume}})
+		WithOptions(modal.ClsWithOptionsParams{Timeout: &timeout, CPU: &cpu}).
+		WithOptions(modal.ClsWithOptionsParams{Timeout: &newTimeout, Memory: &memory, GPU: &gpu}).
+		WithOptions(modal.ClsWithOptionsParams{Secrets: []*modal.Secret{secret}, Volumes: map[string]*modal.Volume{"/mnt/test": volume}})
 
 	instance, err := optioned.Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -116,9 +116,9 @@ func TestClsWithConcurrencyWithBatchingChaining(t *testing.T) {
 
 	timeout := 60 * time.Second
 	chained := cls.
-		WithOptions(modal.ClsWithOptionsOptions{Timeout: &timeout}).
-		WithConcurrency(modal.ClsWithConcurrencyOptions{MaxInputs: 10}).
-		WithBatching(modal.ClsWithBatchingOptions{MaxBatchSize: 11, Wait: 12 * time.Millisecond})
+		WithOptions(modal.ClsWithOptionsParams{Timeout: &timeout}).
+		WithConcurrency(modal.ClsWithConcurrencyParams{MaxInputs: 10}).
+		WithBatching(modal.ClsWithBatchingParams{MaxBatchSize: 11, Wait: 12 * time.Millisecond})
 
 	instance, err := chained.Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -162,14 +162,14 @@ func TestClsWithOptionsRetries(t *testing.T) {
 	backoff := float32(2.0)
 	initial := 2 * time.Second
 	max := 5 * time.Second
-	retries, err := modal.NewRetries(2, &modal.RetriesOptions{
+	retries, err := modal.NewRetries(2, &modal.RetriesParams{
 		BackoffCoefficient: &backoff,
 		InitialDelay:       &initial,
 		MaxDelay:           &max,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{Retries: retries}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Retries: retries}).Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 }
 
@@ -194,22 +194,22 @@ func TestClsWithOptionsInvalidValues(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	timeout := 500 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{Timeout: &timeout}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Timeout: &timeout}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("timeout must be at least 1 second"))
 
 	scaledownWindow := 100 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{ScaledownWindow: &scaledownWindow}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{ScaledownWindow: &scaledownWindow}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("scaledownWindow must be at least 1 second"))
 
 	fractionalTimeout := 1500 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{Timeout: &fractionalTimeout}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Timeout: &fractionalTimeout}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("whole number of seconds"))
 
 	fractionalScaledown := 1500 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{ScaledownWindow: &fractionalScaledown}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{ScaledownWindow: &fractionalScaledown}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("whole number of seconds"))
 }
@@ -246,7 +246,7 @@ func TestWithOptionsEmptySecretsDoesNotReplace(t *testing.T) {
 		},
 	)
 
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{Secrets: []*modal.Secret{}}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Secrets: []*modal.Secret{}}).Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 }
 
@@ -282,6 +282,6 @@ func TestWithOptionsEmptyVolumesDoesNotReplace(t *testing.T) {
 		},
 	)
 
-	_, err = cls.WithOptions(modal.ClsWithOptionsOptions{Volumes: map[string]*modal.Volume{}}).Instance(ctx, nil)
+	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Volumes: map[string]*modal.Volume{}}).Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 }

--- a/modal-go/test/function_call_test.go
+++ b/modal-go/test/function_call_test.go
@@ -56,7 +56,7 @@ func TestFunctionSpawn(t *testing.T) {
 
 	// Get is now expected to timeout.
 	timeout := 1 * time.Second
-	_, err = functionCall.Get(ctx, &modal.FunctionCallGetOptions{Timeout: &timeout})
+	_, err = functionCall.Get(ctx, &modal.FunctionCallGetParams{Timeout: &timeout})
 	g.Expect(err).Should(gomega.HaveOccurred())
 }
 
@@ -76,7 +76,7 @@ func TestFunctionCallGet0(t *testing.T) {
 	// Polling for output with timeout 0 should raise an error, since the
 	// function call has not finished yet.
 	timeout := 0 * time.Second
-	_, err = functionCall.Get(ctx, &modal.FunctionCallGetOptions{Timeout: &timeout})
+	_, err = functionCall.Get(ctx, &modal.FunctionCallGetParams{Timeout: &timeout})
 	g.Expect(err).Should(gomega.HaveOccurred())
 
 	// Wait for the function call to finish.
@@ -85,7 +85,7 @@ func TestFunctionCallGet0(t *testing.T) {
 	g.Expect(result).Should(gomega.Equal(pickle.None{}))
 
 	// Now we can get the result.
-	result, err = functionCall.Get(ctx, &modal.FunctionCallGetOptions{Timeout: &timeout})
+	result, err = functionCall.Get(ctx, &modal.FunctionCallGetParams{Timeout: &timeout})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(result).Should(gomega.Equal(pickle.None{}))
 }

--- a/modal-go/test/function_test.go
+++ b/modal-go/test/function_test.go
@@ -137,7 +137,7 @@ func TestFunctionUpdateAutoscaler(t *testing.T) {
 		},
 	)
 
-	err = f.UpdateAutoscaler(ctx, modal.FunctionUpdateAutoscalerOptions{
+	err = f.UpdateAutoscaler(ctx, modal.FunctionUpdateAutoscalerParams{
 		MinContainers:    ptrU32(1),
 		MaxContainers:    ptrU32(10),
 		BufferContainers: ptrU32(2),
@@ -154,7 +154,7 @@ func TestFunctionUpdateAutoscaler(t *testing.T) {
 		},
 	)
 
-	err = f.UpdateAutoscaler(ctx, modal.FunctionUpdateAutoscalerOptions{
+	err = f.UpdateAutoscaler(ctx, modal.FunctionUpdateAutoscalerParams{
 		MinContainers: ptrU32(2),
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/modal-go/test/image_test.go
+++ b/modal-go/test/image_test.go
@@ -16,7 +16,7 @@ func TestImageFromId(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image, err := tc.Images.FromRegistry("alpine:3.21", nil).Build(ctx, app)
@@ -35,7 +35,7 @@ func TestImageFromRegistry(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image, err := tc.Images.FromRegistry("alpine:3.21", nil).Build(ctx, app)
@@ -53,15 +53,15 @@ func TestImageFromRegistryWithSecret(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	secret, err := tc.Secrets.FromName(ctx, "libmodal-gcp-artifact-registry-test", &modal.SecretFromNameOptions{
+	secret, err := tc.Secrets.FromName(ctx, "libmodal-gcp-artifact-registry-test", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"REGISTRY_USERNAME", "REGISTRY_PASSWORD"},
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	image, err := tc.Images.FromRegistry("us-east1-docker.pkg.dev/modal-prod-367916/private-repo-test/my-image", &modal.ImageFromRegistryOptions{
+	image, err := tc.Images.FromRegistry("us-east1-docker.pkg.dev/modal-prod-367916/private-repo-test/my-image", &modal.ImageFromRegistryParams{
 		Secret: secret,
 	}).Build(ctx, app)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -73,10 +73,10 @@ func TestImageFromAwsEcr(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	secret, err := tc.Secrets.FromName(ctx, "libmodal-aws-ecr-test", &modal.SecretFromNameOptions{
+	secret, err := tc.Secrets.FromName(ctx, "libmodal-aws-ecr-test", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -91,10 +91,10 @@ func TestImageFromGcpArtifactRegistry(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	secret, err := tc.Secrets.FromName(ctx, "libmodal-gcp-artifact-registry-test", &modal.SecretFromNameOptions{
+	secret, err := tc.Secrets.FromName(ctx, "libmodal-gcp-artifact-registry-test", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"SERVICE_ACCOUNT_JSON"},
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -109,7 +109,7 @@ func TestCreateSandboxWithImage(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -127,7 +127,7 @@ func TestImageDelete(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image, err := tc.Images.FromRegistry("alpine:3.13", nil).Build(ctx, app)
@@ -157,7 +157,7 @@ func TestDockerfileCommands(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil).DockerfileCommands(
@@ -165,7 +165,7 @@ func TestDockerfileCommands(t *testing.T) {
 		nil,
 	)
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"cat", "/root/hello.txt"},
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -190,7 +190,7 @@ func TestDockerfileCommandsChaining(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	secret, err := tc.Secrets.FromMap(ctx, map[string]string{"SECRET": "hello"}, nil)
@@ -198,15 +198,15 @@ func TestDockerfileCommandsChaining(t *testing.T) {
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil).
 		DockerfileCommands([]string{"RUN echo ${SECRET:-unset} > /root/layer1.txt"}, nil).
-		DockerfileCommands([]string{"RUN echo ${SECRET:-unset} > /root/layer2.txt"}, &modal.ImageDockerfileCommandsOptions{
+		DockerfileCommands([]string{"RUN echo ${SECRET:-unset} > /root/layer2.txt"}, &modal.ImageDockerfileCommandsParams{
 			Secrets: []*modal.Secret{secret},
 		}).
 		DockerfileCommands([]string{"RUN echo ${SECRET:-unset} > /root/layer3.txt"}, nil).
-		DockerfileCommands([]string{"RUN echo ${SECRET:-unset} > /root/layer4.txt"}, &modal.ImageDockerfileCommandsOptions{
+		DockerfileCommands([]string{"RUN echo ${SECRET:-unset} > /root/layer4.txt"}, &modal.ImageDockerfileCommandsParams{
 			Env: map[string]string{"SECRET": "hello again"},
 		})
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{
 			"cat",
 			"/root/layer1.txt",
@@ -228,7 +228,7 @@ func TestDockerfileCommandsCopyCommandValidation(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -363,12 +363,12 @@ func TestDockerfileCommandsWithOptions(t *testing.T) {
 
 	builtImage, err := mock.Images.FromRegistry("alpine:3.21", nil).
 		DockerfileCommands([]string{"RUN echo layer1"}, nil).
-		DockerfileCommands([]string{"RUN echo layer2"}, &modal.ImageDockerfileCommandsOptions{
+		DockerfileCommands([]string{"RUN echo layer2"}, &modal.ImageDockerfileCommandsParams{
 			Secrets:    []*modal.Secret{secret},
 			GPU:        "A100",
 			ForceBuild: true,
 		}).
-		DockerfileCommands([]string{"RUN echo layer3"}, &modal.ImageDockerfileCommandsOptions{
+		DockerfileCommands([]string{"RUN echo layer3"}, &modal.ImageDockerfileCommandsParams{
 			ForceBuild: true,
 		}).
 		Build(ctx, app)

--- a/modal-go/test/proxy_test.go
+++ b/modal-go/test/proxy_test.go
@@ -14,7 +14,7 @@ func TestCreateSandboxWithProxy(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -24,7 +24,7 @@ func TestCreateSandboxWithProxy(t *testing.T) {
 	g.Expect(proxy.ProxyId).ShouldNot(gomega.BeEmpty())
 	g.Expect(strings.HasPrefix(proxy.ProxyId, "pr-")).To(gomega.BeTrue())
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Proxy:   proxy,
 		Command: []string{"echo", "hello, Sandbox with Proxy"},
 	})

--- a/modal-go/test/queue_test.go
+++ b/modal-go/test/queue_test.go
@@ -73,12 +73,12 @@ func TestQueueSuite1(t *testing.T) {
 	g.Expect(queue.Put(ctx, 432, nil)).ToNot(gomega.HaveOccurred())
 
 	var timeout time.Duration
-	item, err = queue.Get(ctx, &modal.QueueGetOptions{Timeout: &timeout})
+	item, err = queue.Get(ctx, &modal.QueueGetParams{Timeout: &timeout})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(item).To(gomega.Equal(int64(432)))
 
 	// queue is now empty – non-blocking get should error
-	_, err = queue.Get(ctx, &modal.QueueGetOptions{Timeout: &timeout})
+	_, err = queue.Get(ctx, &modal.QueueGetParams{Timeout: &timeout})
 	g.Expect(errors.As(err, &modal.QueueEmptyError{})).To(gomega.BeTrue())
 
 	n, err = queue.Len(ctx, nil)
@@ -121,7 +121,7 @@ func TestQueueSuite2(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for v, err := range queue.Iterate(ctx, &modal.QueueIterateOptions{ItemPollTimeout: time.Second}) {
+		for v, err := range queue.Iterate(ctx, &modal.QueueIterateParams{ItemPollTimeout: time.Second}) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			results = append(results, v.(int64))
 		}
@@ -161,14 +161,14 @@ func TestQueueNonBlocking(t *testing.T) {
 	defer queue.CloseEphemeral()
 
 	var timeout time.Duration
-	err = queue.Put(ctx, 123, &modal.QueuePutOptions{Timeout: &timeout})
+	err = queue.Put(ctx, 123, &modal.QueuePutParams{Timeout: &timeout})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	n, err := queue.Len(ctx, nil)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(n).To(gomega.Equal(1))
 
-	item, err := queue.Get(ctx, &modal.QueueGetOptions{Timeout: &timeout})
+	item, err := queue.Get(ctx, &modal.QueueGetParams{Timeout: &timeout})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(item).To(gomega.Equal(int64(123)))
 }
@@ -179,7 +179,7 @@ func TestQueueNonEphemeral(t *testing.T) {
 	ctx := context.Background()
 
 	queueName := "test-queue-" + strconv.FormatInt(time.Now().UnixNano(), 10)
-	queue1, err := tc.Queues.FromName(ctx, queueName, &modal.QueueFromNameOptions{CreateIfMissing: true})
+	queue1, err := tc.Queues.FromName(ctx, queueName, &modal.QueueFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(queue1.Name).To(gomega.Equal(queueName))
 

--- a/modal-go/test/retries_test.go
+++ b/modal-go/test/retries_test.go
@@ -14,7 +14,7 @@ func TestRetriesConstructor(t *testing.T) {
 	backoff := float32(2.0)
 	initial := 2 * time.Second
 	max := 5 * time.Second
-	r, err := modal.NewRetries(2, &modal.RetriesOptions{
+	r, err := modal.NewRetries(2, &modal.RetriesParams{
 		BackoffCoefficient: &backoff,
 		InitialDelay:       &initial,
 		MaxDelay:           &max,
@@ -33,7 +33,7 @@ func TestRetriesConstructor(t *testing.T) {
 	g.Expect(r.MaxDelay).To(gomega.Equal(60 * time.Second))
 
 	zeroDelay := 0 * time.Millisecond
-	r, err = modal.NewRetries(1, &modal.RetriesOptions{
+	r, err = modal.NewRetries(1, &modal.RetriesParams{
 		InitialDelay: &zeroDelay,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -46,17 +46,17 @@ func TestRetriesConstructor(t *testing.T) {
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("maxRetries"))
 
 	invalidBackoff := float32(0.9)
-	_, err = modal.NewRetries(0, &modal.RetriesOptions{BackoffCoefficient: &invalidBackoff})
+	_, err = modal.NewRetries(0, &modal.RetriesParams{BackoffCoefficient: &invalidBackoff})
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("backoffCoefficient"))
 
 	invalidInitial := 61 * time.Second
-	_, err = modal.NewRetries(0, &modal.RetriesOptions{InitialDelay: &invalidInitial})
+	_, err = modal.NewRetries(0, &modal.RetriesParams{InitialDelay: &invalidInitial})
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("initialDelay"))
 
 	invalidMax := 500 * time.Millisecond
-	_, err = modal.NewRetries(0, &modal.RetriesOptions{MaxDelay: &invalidMax})
+	_, err = modal.NewRetries(0, &modal.RetriesParams{MaxDelay: &invalidMax})
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("maxDelay"))
 }

--- a/modal-go/test/sandbox_filesystem_snapshot_test.go
+++ b/modal-go/test/sandbox_filesystem_snapshot_test.go
@@ -15,7 +15,7 @@ func TestSnapshotFilesystem(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)

--- a/modal-go/test/sandbox_filesystem_test.go
+++ b/modal-go/test/sandbox_filesystem_test.go
@@ -13,7 +13,7 @@ import (
 func createSandbox(g *gomega.WithT) *modal.Sandbox {
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)

--- a/modal-go/test/sandbox_test.go
+++ b/modal-go/test/sandbox_test.go
@@ -17,7 +17,7 @@ func TestCreateOneSandbox(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(app.Name).To(gomega.Equal("libmodal-test"))
 
@@ -41,12 +41,12 @@ func TestPassCatToStdin(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{Command: []string{"cat"}})
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{Command: []string{"cat"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer terminateSandbox(g, sb)
 
@@ -65,7 +65,7 @@ func TestIgnoreLargeStdout(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("python:3.13-alpine", nil)
@@ -74,7 +74,7 @@ func TestIgnoreLargeStdout(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer terminateSandbox(g, sb)
 
-	p, err := sb.Exec(ctx, []string{"python", "-c", `print("a" * 1_000_000)`}, &modal.SandboxExecOptions{Stdout: modal.Ignore})
+	p, err := sb.Exec(ctx, []string{"python", "-c", `print("a" * 1_000_000)`}, &modal.SandboxExecParams{Stdout: modal.Ignore})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	buf, err := io.ReadAll(p.Stdout)
@@ -92,14 +92,14 @@ func TestSandboxCreateOptions(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"echo", "hello, params"},
 		Cloud:   "aws",
 		Regions: []string{"us-east-1", "us-west-2"},
@@ -115,13 +115,13 @@ func TestSandboxCreateOptions(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(exitCode).Should(gomega.Equal(0))
 
-	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Cloud: "invalid-cloud",
 	})
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("InvalidArgument"))
 
-	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Regions: []string{"invalid-region"},
 	})
 	g.Expect(err).Should(gomega.HaveOccurred())
@@ -133,7 +133,7 @@ func TestSandboxExecOptions(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -143,7 +143,7 @@ func TestSandboxExecOptions(t *testing.T) {
 	defer terminateSandbox(g, sb)
 
 	// Test with a custom working directory and timeout.
-	p, err := sb.Exec(ctx, []string{"pwd"}, &modal.SandboxExecOptions{
+	p, err := sb.Exec(ctx, []string{"pwd"}, &modal.SandboxExecParams{
 		Workdir: "/tmp",
 		Timeout: 5,
 	})
@@ -163,19 +163,19 @@ func TestSandboxWithVolume(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-sandbox-volume", &modal.VolumeFromNameOptions{
+	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-sandbox-volume", &modal.VolumeFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"echo", "volume test"},
 		Volumes: map[string]*modal.Volume{
 			"/mnt/test": volume,
@@ -195,14 +195,14 @@ func TestSandboxWithReadOnlyVolume(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-sandbox-volume", &modal.VolumeFromNameOptions{
+	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-sandbox-volume", &modal.VolumeFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -210,7 +210,7 @@ func TestSandboxWithReadOnlyVolume(t *testing.T) {
 	readOnlyVolume := volume.ReadOnly()
 	g.Expect(readOnlyVolume.IsReadOnly()).To(gomega.BeTrue())
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"sh", "-c", "echo 'test' > /mnt/test/test.txt"},
 		Volumes: map[string]*modal.Volume{
 			"/mnt/test": readOnlyVolume,
@@ -233,14 +233,14 @@ func TestSandboxWithTunnels(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command:          []string{"cat"},
 		EncryptedPorts:   []int{8443},
 		UnencryptedPorts: []int{8080},
@@ -281,15 +281,15 @@ func TestCreateSandboxWithSecrets(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	secret, err := tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameOptions{RequiredKeys: []string{"c"}})
+	secret, err := tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameParams{RequiredKeys: []string{"c"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{Secrets: []*modal.Secret{secret}, Command: []string{"printenv", "c"}})
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{Secrets: []*modal.Secret{secret}, Command: []string{"printenv", "c"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	output, err := io.ReadAll(sb.Stdout)
@@ -301,12 +301,12 @@ func TestSandboxPollAndReturnCode(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{Command: []string{"cat"}})
+	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{Command: []string{"cat"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	pollResult, err := sandbox.Poll(ctx)
@@ -334,12 +334,12 @@ func TestSandboxPollAfterFailure(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sandbox, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"sh", "-c", "exit 42"},
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -359,14 +359,14 @@ func TestCreateSandboxWithNetworkAccessParams(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command:       []string{"echo", "hello, network access"},
 		BlockNetwork:  false,
 		CIDRAllowlist: []string{"10.0.0.0/8", "192.168.0.0/16"},
@@ -381,14 +381,14 @@ func TestCreateSandboxWithNetworkAccessParams(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(exitCode).Should(gomega.Equal(0))
 
-	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		BlockNetwork:  false,
 		CIDRAllowlist: []string{"not-an-ip/8"},
 	})
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("Invalid CIDR: not-an-ip/8"))
 
-	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		BlockNetwork:  true,
 		CIDRAllowlist: []string{"10.0.0.0/8"},
 	})
@@ -401,7 +401,7 @@ func TestSandboxExecSecret(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -410,13 +410,13 @@ func TestSandboxExecSecret(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer terminateSandbox(g, sb)
 
-	secret, err := tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameOptions{RequiredKeys: []string{"c"}})
+	secret, err := tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameParams{RequiredKeys: []string{"c"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	secret2, err := tc.Secrets.FromMap(ctx, map[string]string{"d": "3"}, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	p, err := sb.Exec(ctx, []string{"printenv", "c", "d"}, &modal.SandboxExecOptions{Secrets: []*modal.Secret{secret, secret2}})
+	p, err := sb.Exec(ctx, []string{"printenv", "c", "d"}, &modal.SandboxExecParams{Secrets: []*modal.Secret{secret, secret2}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	buf, err := io.ReadAll(p.Stdout)
@@ -429,7 +429,7 @@ func TestSandboxFromId(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -450,12 +450,12 @@ func TestSandboxWithWorkdir(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"pwd"},
 		Workdir: "/tmp",
 	})
@@ -470,7 +470,7 @@ func TestSandboxWithWorkdir(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(exitCode).To(gomega.Equal(0))
 
-	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Workdir: "relative/path",
 	})
 	g.Expect(err).Should(gomega.HaveOccurred())
@@ -482,7 +482,7 @@ func TestSandboxSetTagsAndList(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -494,7 +494,7 @@ func TestSandboxSetTagsAndList(t *testing.T) {
 	unique := fmt.Sprintf("%d", rand.Int())
 
 	var before []string
-	it, err := tc.Sandboxes.List(ctx, &modal.SandboxListOptions{Tags: map[string]string{"test-key": unique}})
+	it, err := tc.Sandboxes.List(ctx, &modal.SandboxListParams{Tags: map[string]string{"test-key": unique}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	for s, err := range it {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -506,7 +506,7 @@ func TestSandboxSetTagsAndList(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	var after []string
-	it, err = tc.Sandboxes.List(ctx, &modal.SandboxListOptions{Tags: map[string]string{"test-key": unique}})
+	it, err = tc.Sandboxes.List(ctx, &modal.SandboxListParams{Tags: map[string]string{"test-key": unique}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	for s, err := range it {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -520,7 +520,7 @@ func TestSandboxTags(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -545,7 +545,7 @@ func TestSandboxTags(t *testing.T) {
 	g.Expect(retrievedTags).To(gomega.Equal(map[string]string{"key-a": tagA, "key-b": tagB, "key-c": tagC}))
 
 	var ids []string
-	it, err := tc.Sandboxes.List(ctx, &modal.SandboxListOptions{Tags: map[string]string{"key-a": tagA}})
+	it, err := tc.Sandboxes.List(ctx, &modal.SandboxListParams{Tags: map[string]string{"key-a": tagA}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	for s, err := range it {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -554,7 +554,7 @@ func TestSandboxTags(t *testing.T) {
 	g.Expect(ids).To(gomega.Equal([]string{sb.SandboxId}))
 
 	ids = nil
-	it, err = tc.Sandboxes.List(ctx, &modal.SandboxListOptions{Tags: map[string]string{"key-a": tagA, "key-b": tagB}})
+	it, err = tc.Sandboxes.List(ctx, &modal.SandboxListParams{Tags: map[string]string{"key-a": tagA, "key-b": tagB}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	for s, err := range it {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -563,7 +563,7 @@ func TestSandboxTags(t *testing.T) {
 	g.Expect(ids).To(gomega.Equal([]string{sb.SandboxId}))
 
 	ids = nil
-	it, err = tc.Sandboxes.List(ctx, &modal.SandboxListOptions{Tags: map[string]string{"key-a": tagA, "key-b": tagB, "key-d": "not-set"}})
+	it, err = tc.Sandboxes.List(ctx, &modal.SandboxListParams{Tags: map[string]string{"key-a": tagA, "key-b": tagB, "key-d": "not-set"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	for s, err := range it {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -577,7 +577,7 @@ func TestSandboxListByAppId(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -587,7 +587,7 @@ func TestSandboxListByAppId(t *testing.T) {
 	defer terminateSandbox(g, sb)
 
 	count := 0
-	it, err := tc.Sandboxes.List(ctx, &modal.SandboxListOptions{AppId: app.AppId})
+	it, err := tc.Sandboxes.List(ctx, &modal.SandboxListParams{AppId: app.AppId})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	for s, err := range it {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -605,14 +605,14 @@ func TestNamedSandbox(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
 
 	sandboxName := fmt.Sprintf("test-sandbox-%d", rand.Int())
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Name:    sandboxName,
 		Command: []string{"sleep", "60"},
 	})
@@ -629,7 +629,7 @@ func TestNamedSandbox(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(sb2FromName.SandboxId).To(gomega.Equal(sb1FromName.SandboxId))
 
-	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{
+	_, err = tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Name:    sandboxName,
 		Command: []string{"sleep", "60"},
 	})

--- a/modal-go/test/secret_test.go
+++ b/modal-go/test/secret_test.go
@@ -28,13 +28,13 @@ func TestSecretFromNameWithRequiredKeys(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	secret, err := tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameOptions{
+	secret, err := tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"a", "b", "c"},
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(secret.SecretId).Should(gomega.HavePrefix("st-"))
 
-	_, err = tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameOptions{
+	_, err = tc.Secrets.FromName(ctx, "libmodal-test-secret", &modal.SecretFromNameParams{
 		RequiredKeys: []string{"a", "b", "c", "missing-key"},
 	})
 	g.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("Secret is missing key(s): missing-key")))
@@ -45,7 +45,7 @@ func TestSecretFromMap(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameOptions{CreateIfMissing: true})
+	app, err := tc.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	image := tc.Images.FromRegistry("alpine:3.21", nil)
@@ -54,7 +54,7 @@ func TestSecretFromMap(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(secret.SecretId).Should(gomega.HavePrefix("st-"))
 
-	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateOptions{Secrets: []*modal.Secret{secret}, Command: []string{"printenv", "key"}})
+	sb, err := tc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{Secrets: []*modal.Secret{secret}, Command: []string{"printenv", "key"}})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	output, err := io.ReadAll(sb.Stdout)

--- a/modal-go/test/volume_test.go
+++ b/modal-go/test/volume_test.go
@@ -13,7 +13,7 @@ func TestVolumeFromName(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-volume", &modal.VolumeFromNameOptions{
+	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-volume", &modal.VolumeFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -30,7 +30,7 @@ func TestVolumeReadOnly(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
-	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-volume", &modal.VolumeFromNameOptions{
+	volume, err := tc.Volumes.FromName(ctx, "libmodal-test-volume", &modal.VolumeFromNameParams{
 		CreateIfMissing: true,
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/modal-go/testsupport/grpcmock/mock.go
+++ b/modal-go/testsupport/grpcmock/mock.go
@@ -33,7 +33,7 @@ func NewMockClient() *MockClient {
 
 	conn := &mockClientConn{mock: mc}
 
-	modalClient, err := modal.NewClientWithOptions(modal.ClientOptions{
+	modalClient, err := modal.NewClientWithOptions(modal.ClientParams{
 		TokenId:            "test-token-id",
 		TokenSecret:        "test-token-secret",
 		Environment:        "test",

--- a/modal-go/volume.go
+++ b/modal-go/volume.go
@@ -20,26 +20,26 @@ type Volume struct {
 	cancelEphemeral context.CancelFunc
 }
 
-// VolumeFromNameOptions are options for finding Modal Volumes.
-type VolumeFromNameOptions struct {
+// VolumeFromNameParams are options for finding Modal Volumes.
+type VolumeFromNameParams struct {
 	Environment     string
 	CreateIfMissing bool
 }
 
 // FromName references a Volume by its name.
-func (s *VolumeService) FromName(ctx context.Context, name string, options *VolumeFromNameOptions) (*Volume, error) {
-	if options == nil {
-		options = &VolumeFromNameOptions{}
+func (s *VolumeService) FromName(ctx context.Context, name string, params *VolumeFromNameParams) (*Volume, error) {
+	if params == nil {
+		params = &VolumeFromNameParams{}
 	}
 
 	creationType := pb.ObjectCreationType_OBJECT_CREATION_TYPE_UNSPECIFIED
-	if options.CreateIfMissing {
+	if params.CreateIfMissing {
 		creationType = pb.ObjectCreationType_OBJECT_CREATION_TYPE_CREATE_IF_MISSING
 	}
 
 	resp, err := s.client.cpClient.VolumeGetOrCreate(ctx, pb.VolumeGetOrCreateRequest_builder{
 		DeploymentName:     name,
-		EnvironmentName:    environmentName(options.Environment, s.client.profile),
+		EnvironmentName:    environmentName(params.Environment, s.client.profile),
 		ObjectCreationType: creationType,
 	}.Build())
 
@@ -68,20 +68,20 @@ func (v *Volume) IsReadOnly() bool {
 	return v.readOnly
 }
 
-// VolumeEphemeralOptions are options for client.Volumes.Ephemeral.
-type VolumeEphemeralOptions struct {
+// VolumeEphemeralParams are options for client.Volumes.Ephemeral.
+type VolumeEphemeralParams struct {
 	Environment string
 }
 
 // Ephemeral creates a nameless, temporary Volume, that persists until CloseEphemeral is called, or the process exits.
-func (s *VolumeService) Ephemeral(ctx context.Context, options *VolumeEphemeralOptions) (*Volume, error) {
-	if options == nil {
-		options = &VolumeEphemeralOptions{}
+func (s *VolumeService) Ephemeral(ctx context.Context, params *VolumeEphemeralParams) (*Volume, error) {
+	if params == nil {
+		params = &VolumeEphemeralParams{}
 	}
 
 	resp, err := s.client.cpClient.VolumeGetOrCreate(ctx, pb.VolumeGetOrCreateRequest_builder{
 		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
-		EnvironmentName:    environmentName(options.Environment, s.client.profile),
+		EnvironmentName:    environmentName(params.Environment, s.client.profile),
 	}.Build())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**(note this is a PR on top of #139)**

This should also be a pure renaming, to align with the naming convention from e.g. the Stripe and OpenAI Go SDKs.
