### PR TITLE
Always pass `Params` as pointers

### DIFF
--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -48,7 +48,7 @@ type Client struct {
 
 // NewClient generates a new client with the default profile configuration read from environment variables and ~/.modal.toml.
 func NewClient() (*Client, error) {
-	return NewClientWithOptions(ClientParams{})
+	return NewClientWithOptions(nil)
 }
 
 // ClientParams defines credentials and options for initializing the Modal client.
@@ -61,7 +61,11 @@ type ClientParams struct {
 }
 
 // NewClientWithOptions generates a new client and allows overriding options in the default profile configuration.
-func NewClientWithOptions(params ClientParams) (*Client, error) {
+func NewClientWithOptions(params *ClientParams) (*Client, error) {
+	if params == nil {
+		params = &ClientParams{}
+	}
+
 	var cfg config
 	if params.Config != nil {
 		cfg = *params.Config

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -159,7 +159,11 @@ func (c *Cls) Instance(ctx context.Context, params map[string]any) (*ClsInstance
 }
 
 // WithOptions overrides the static Function configuration at runtime.
-func (c *Cls) WithOptions(params ClsWithOptionsParams) *Cls {
+func (c *Cls) WithOptions(params *ClsWithOptionsParams) *Cls {
+	if params == nil {
+		params = &ClsWithOptionsParams{}
+	}
+
 	var secretsPtr *[]*Secret
 	if params.Secrets != nil {
 		s := params.Secrets
@@ -201,7 +205,11 @@ func (c *Cls) WithOptions(params ClsWithOptionsParams) *Cls {
 }
 
 // WithConcurrency creates an instance of the Cls with input concurrency enabled or overridden with new values.
-func (c *Cls) WithConcurrency(params ClsWithConcurrencyParams) *Cls {
+func (c *Cls) WithConcurrency(params *ClsWithConcurrencyParams) *Cls {
+	if params == nil {
+		params = &ClsWithConcurrencyParams{}
+	}
+
 	merged := mergeServiceParams(c.params, &serviceParams{
 		maxConcurrentInputs:    &params.MaxInputs,
 		targetConcurrentInputs: params.TargetInputs,
@@ -218,7 +226,11 @@ func (c *Cls) WithConcurrency(params ClsWithConcurrencyParams) *Cls {
 }
 
 // WithBatching creates an instance of the Cls with dynamic batching enabled or overridden with new values.
-func (c *Cls) WithBatching(params ClsWithBatchingParams) *Cls {
+func (c *Cls) WithBatching(params *ClsWithBatchingParams) *Cls {
+	if params == nil {
+		params = &ClsWithBatchingParams{}
+	}
+
 	merged := mergeServiceParams(c.params, &serviceParams{
 		batchMaxSize: &params.MaxBatchSize,
 		batchWait:    &params.Wait,

--- a/modal-go/examples/cls-call-with-options/main.go
+++ b/modal-go/examples/cls-call-with-options/main.go
@@ -40,10 +40,10 @@ func main() {
 	}
 
 	instanceWithOptions, err := cls.
-		WithOptions(modal.ClsWithOptionsParams{
+		WithOptions(&modal.ClsWithOptionsParams{
 			Secrets: []*modal.Secret{secret},
 		}).
-		WithConcurrency(modal.ClsWithConcurrencyParams{MaxInputs: 1}).
+		WithConcurrency(&modal.ClsWithConcurrencyParams{MaxInputs: 1}).
 		Instance(ctx, nil)
 	if err != nil {
 		log.Fatalf("Failed to create Cls instance with options: %v", err)

--- a/modal-go/examples/init-client/main.go
+++ b/modal-go/examples/init-client/main.go
@@ -23,7 +23,7 @@ func main() {
 		log.Fatal("CUSTOM_MODAL_SECRET environment variable not set")
 	}
 
-	mc, err := modal.NewClientWithOptions(modal.ClientParams{
+	mc, err := modal.NewClientWithOptions(&modal.ClientParams{
 		TokenId:     modal_id,
 		TokenSecret: modal_secret,
 	})

--- a/modal-go/test/cls_with_options_test.go
+++ b/modal-go/test/cls_with_options_test.go
@@ -71,9 +71,9 @@ func TestClsWithOptionsStacking(t *testing.T) {
 	newTimeout := 60 * time.Second
 
 	optioned := cls.
-		WithOptions(modal.ClsWithOptionsParams{Timeout: &timeout, CPU: &cpu}).
-		WithOptions(modal.ClsWithOptionsParams{Timeout: &newTimeout, Memory: &memory, GPU: &gpu}).
-		WithOptions(modal.ClsWithOptionsParams{Secrets: []*modal.Secret{secret}, Volumes: map[string]*modal.Volume{"/mnt/test": volume}})
+		WithOptions(&modal.ClsWithOptionsParams{Timeout: &timeout, CPU: &cpu}).
+		WithOptions(&modal.ClsWithOptionsParams{Timeout: &newTimeout, Memory: &memory, GPU: &gpu}).
+		WithOptions(&modal.ClsWithOptionsParams{Secrets: []*modal.Secret{secret}, Volumes: map[string]*modal.Volume{"/mnt/test": volume}})
 
 	instance, err := optioned.Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -116,9 +116,9 @@ func TestClsWithConcurrencyWithBatchingChaining(t *testing.T) {
 
 	timeout := 60 * time.Second
 	chained := cls.
-		WithOptions(modal.ClsWithOptionsParams{Timeout: &timeout}).
-		WithConcurrency(modal.ClsWithConcurrencyParams{MaxInputs: 10}).
-		WithBatching(modal.ClsWithBatchingParams{MaxBatchSize: 11, Wait: 12 * time.Millisecond})
+		WithOptions(&modal.ClsWithOptionsParams{Timeout: &timeout}).
+		WithConcurrency(&modal.ClsWithConcurrencyParams{MaxInputs: 10}).
+		WithBatching(&modal.ClsWithBatchingParams{MaxBatchSize: 11, Wait: 12 * time.Millisecond})
 
 	instance, err := chained.Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -169,7 +169,7 @@ func TestClsWithOptionsRetries(t *testing.T) {
 	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Retries: retries}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{Retries: retries}).Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 }
 
@@ -194,22 +194,22 @@ func TestClsWithOptionsInvalidValues(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	timeout := 500 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Timeout: &timeout}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{Timeout: &timeout}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("timeout must be at least 1 second"))
 
 	scaledownWindow := 100 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{ScaledownWindow: &scaledownWindow}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{ScaledownWindow: &scaledownWindow}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("scaledownWindow must be at least 1 second"))
 
 	fractionalTimeout := 1500 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Timeout: &fractionalTimeout}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{Timeout: &fractionalTimeout}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("whole number of seconds"))
 
 	fractionalScaledown := 1500 * time.Millisecond
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{ScaledownWindow: &fractionalScaledown}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{ScaledownWindow: &fractionalScaledown}).Instance(ctx, nil)
 	g.Expect(err).Should(gomega.HaveOccurred())
 	g.Expect(err.Error()).Should(gomega.ContainSubstring("whole number of seconds"))
 }
@@ -246,7 +246,7 @@ func TestWithOptionsEmptySecretsDoesNotReplace(t *testing.T) {
 		},
 	)
 
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Secrets: []*modal.Secret{}}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{Secrets: []*modal.Secret{}}).Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 }
 
@@ -282,6 +282,6 @@ func TestWithOptionsEmptyVolumesDoesNotReplace(t *testing.T) {
 		},
 	)
 
-	_, err = cls.WithOptions(modal.ClsWithOptionsParams{Volumes: map[string]*modal.Volume{}}).Instance(ctx, nil)
+	_, err = cls.WithOptions(&modal.ClsWithOptionsParams{Volumes: map[string]*modal.Volume{}}).Instance(ctx, nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 }

--- a/modal-go/testsupport/grpcmock/mock.go
+++ b/modal-go/testsupport/grpcmock/mock.go
@@ -33,7 +33,7 @@ func NewMockClient() *MockClient {
 
 	conn := &mockClientConn{mock: mc}
 
-	modalClient, err := modal.NewClientWithOptions(modal.ClientParams{
+	modalClient, err := modal.NewClientWithOptions(&modal.ClientParams{
 		TokenId:            "test-token-id",
 		TokenSecret:        "test-token-secret",
 		Environment:        "test",


### PR DESCRIPTION
**(note this is a PR on top of #140)**

This is just to make the API consistent. Open to feedback.