### PR TITLE
Fix package doc comment in doc.go

### DIFF
--- a/modal-go/.golangci.toml
+++ b/modal-go/.golangci.toml
@@ -4,7 +4,7 @@ version = "2"
 disable = ["errcheck"]
 
 [linters.settings.staticcheck]
-checks = ["all", "-ST1000"]
+checks = ["all"]
 
 [formatters]
 enable = ["gofmt", "goimports"]

--- a/modal-go/doc.go
+++ b/modal-go/doc.go
@@ -30,5 +30,4 @@
 //
 // For additional examples and language-parity tests, see
 // https://github.com/modal-labs/libmodal.
-
 package modal

--- a/modal-go/testsupport/grpcmock/mock.go
+++ b/modal-go/testsupport/grpcmock/mock.go
@@ -1,3 +1,4 @@
+// Package grpcmock provides utilities for mocking gRPC services in tests.
 package grpcmock
 
 import (


### PR DESCRIPTION
**(note this is a PR on top of #142)**

In Go there must apparently be no blank lines between the package comment and package declaration.