### PR TITLE
Merge `env` and `secrets` earlier in the flow

### DIFF
--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -143,6 +143,9 @@ func (c *Cls) Instance(ctx context.Context, parameters map[string]any) (*ClsInst
 	if len(c.schema) == 0 && !hasOptions(c.serviceOptions) {
 		functionID = c.serviceFunctionID
 	} else {
+		if c.serviceOptions == nil {
+			c.serviceOptions = &serviceOptions{}
+		}
 		boundFunctionID, err := c.bindParameters(ctx, parameters)
 		if err != nil {
 			return nil, err
@@ -252,20 +255,21 @@ func (c *Cls) WithBatching(params *ClsWithBatchingParams) *Cls {
 
 // bindParameters processes the parameters and binds them to the class function.
 func (c *Cls) bindParameters(ctx context.Context, parameters map[string]any) (string, error) {
-	var envSecret *Secret
-	var err error
-	if c.serviceOptions != nil && c.serviceOptions.env != nil && len(*c.serviceOptions.env) > 0 {
-		envSecret, err = c.client.Secrets.FromMap(ctx, *c.serviceOptions.env, nil)
-		if err != nil {
-			return "", err
-		}
+	mergedSecrets, err := mergeEnvIntoSecrets(ctx, c.client, c.serviceOptions.env, c.serviceOptions.secrets)
+	if err != nil {
+		return "", err
 	}
+
+	mergedOptions := mergeServiceOptions(c.serviceOptions, &serviceOptions{
+		secrets: &mergedSecrets,
+		env:     nil,
+	})
 
 	serializedParams, err := encodeParameterSet(c.schema, parameters)
 	if err != nil {
 		return "", fmt.Errorf("failed to serialize parameters: %w", err)
 	}
-	functionOptions, err := buildFunctionOptionsProto(c.serviceOptions, envSecret)
+	functionOptions, err := buildFunctionOptionsProto(mergedOptions)
 	if err != nil {
 		return "", fmt.Errorf("failed to build function options: %w", err)
 	}
@@ -458,7 +462,7 @@ func mergeServiceOptions(base, new *serviceOptions) *serviceOptions {
 	return merged
 }
 
-func buildFunctionOptionsProto(options *serviceOptions, envSecret *Secret) (*pb.FunctionOptions, error) {
+func buildFunctionOptionsProto(options *serviceOptions) (*pb.FunctionOptions, error) {
 	if !hasOptions(options) {
 		return nil, nil
 	}
@@ -490,12 +494,6 @@ func buildFunctionOptionsProto(options *serviceOptions, envSecret *Secret) (*pb.
 				secretIds = append(secretIds, secret.SecretID)
 			}
 		}
-	}
-	if (options.env != nil && len(*options.env) > 0) != (envSecret != nil) {
-		return nil, fmt.Errorf("internal error: env and envSecret must both be provided or neither be provided")
-	}
-	if envSecret != nil {
-		secretIds = append(secretIds, envSecret.SecretID)
 	}
 
 	builder.SecretIds = secretIds

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -143,10 +143,11 @@ func (c *Cls) Instance(ctx context.Context, parameters map[string]any) (*ClsInst
 	if len(c.schema) == 0 && !hasOptions(c.serviceOptions) {
 		functionID = c.serviceFunctionID
 	} else {
-		if c.serviceOptions == nil {
-			c.serviceOptions = &serviceOptions{}
+		opts := c.serviceOptions
+		if opts == nil {
+			opts = &serviceOptions{}
 		}
-		boundFunctionID, err := c.bindParameters(ctx, parameters)
+		boundFunctionID, err := c.bindParameters(ctx, parameters, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -254,13 +255,13 @@ func (c *Cls) WithBatching(params *ClsWithBatchingParams) *Cls {
 }
 
 // bindParameters processes the parameters and binds them to the class function.
-func (c *Cls) bindParameters(ctx context.Context, parameters map[string]any) (string, error) {
-	mergedSecrets, err := mergeEnvIntoSecrets(ctx, c.client, c.serviceOptions.env, c.serviceOptions.secrets)
+func (c *Cls) bindParameters(ctx context.Context, parameters map[string]any, opts *serviceOptions) (string, error) {
+	mergedSecrets, err := mergeEnvIntoSecrets(ctx, c.client, opts.env, opts.secrets)
 	if err != nil {
 		return "", err
 	}
 
-	mergedOptions := mergeServiceOptions(c.serviceOptions, &serviceOptions{
+	mergedOptions := mergeServiceOptions(opts, &serviceOptions{
 		secrets: &mergedSecrets,
 		env:     nil,
 	})

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -263,7 +263,7 @@ func (c *Cls) bindParameters(ctx context.Context, parameters map[string]any, opt
 
 	mergedOptions := mergeServiceOptions(opts, &serviceOptions{
 		secrets: &mergedSecrets,
-		env:     nil,
+		env:     nil, // nil'ing env just to clarify it's not needed anymore
 	})
 
 	serializedParams, err := encodeParameterSet(c.schema, parameters)

--- a/modal-go/cls_test.go
+++ b/modal-go/cls_test.go
@@ -9,77 +9,7 @@ import (
 func TestBuildFunctionOptionsProto_NilOptions(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	options, err := buildFunctionOptionsProto(nil, nil)
+	options, err := buildFunctionOptionsProto(nil)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(options).Should(gomega.BeNil())
-}
-
-func TestBuildFunctionOptionsProto_MergesEnvAndSecrets(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	secret := &Secret{SecretID: "test-secret-1"}
-
-	envVars := map[string]string{"B": "2"}
-	envSecret := &Secret{SecretID: "test-env-secret"}
-
-	_, err := buildFunctionOptionsProto(&serviceOptions{env: &envVars}, nil)
-	g.Expect(err).Should(gomega.HaveOccurred())
-	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: env and envSecret must both be provided or neither be provided"))
-
-	mem := 1 // need to pass a non-empty serviceOptions to pass the !hasParams() check
-	_, err = buildFunctionOptionsProto(&serviceOptions{memory: &mem}, envSecret)
-	g.Expect(err).Should(gomega.HaveOccurred())
-	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: env and envSecret must both be provided or neither be provided"))
-
-	functionOptions, err := buildFunctionOptionsProto(&serviceOptions{
-		env:     &envVars,
-		secrets: &[]*Secret{secret},
-	}, envSecret)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.HaveLen(2))
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.ContainElement(secret.SecretID))
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.ContainElement(envSecret.SecretID))
-	g.Expect(functionOptions.GetReplaceSecretIds()).To(gomega.BeTrue())
-}
-
-func TestBuildFunctionOptionsProto_WithOnlyEnvParameter(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	envVars := map[string]string{"B": "2"}
-	envSecret := &Secret{SecretID: "test-env-secret"}
-
-	functionOptions, err := buildFunctionOptionsProto(&serviceOptions{
-		env: &envVars,
-	}, envSecret)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.HaveLen(1))
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.ContainElement(envSecret.SecretID))
-	g.Expect(functionOptions.GetReplaceSecretIds()).To(gomega.BeTrue())
-}
-
-func TestBuildFunctionOptionsProto_EmptyEnv_WithSecrets(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	secret := &Secret{SecretID: "test-secret-1"}
-
-	params := &serviceOptions{env: &map[string]string{}, secrets: &[]*Secret{secret}}
-
-	functionOptions, err := buildFunctionOptionsProto(params, nil)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.HaveLen(1))
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.ContainElement(secret.SecretID))
-	g.Expect(functionOptions.GetReplaceSecretIds()).To(gomega.BeTrue())
-}
-
-func TestBuildFunctionOptionsProto_EmptyEnv_NoSecrets(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	functionOptions, err := buildFunctionOptionsProto(&serviceOptions{env: &map[string]string{}}, nil)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	g.Expect(functionOptions.GetSecretIds()).To(gomega.HaveLen(0))
-	g.Expect(functionOptions.GetReplaceSecretIds()).To(gomega.BeFalse())
 }

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -196,16 +196,14 @@ func (image *Image) Build(ctx context.Context, app *App) (*Image, error) {
 	var currentImageID string
 
 	for i, currentLayer := range image.layers {
-		var secretIds []string
-		for _, secret := range currentLayer.secrets {
-			secretIds = append(secretIds, secret.SecretID)
+		mergedSecrets, err := mergeEnvIntoSecrets(ctx, image.client, &currentLayer.env, &currentLayer.secrets)
+		if err != nil {
+			return nil, err
 		}
-		if len(currentLayer.env) > 0 {
-			envSecret, err := image.client.Secrets.FromMap(ctx, currentLayer.env, nil)
-			if err != nil {
-				return nil, err
-			}
-			secretIds = append(secretIds, envSecret.SecretID)
+
+		var secretIds []string
+		for _, secret := range mergedSecrets {
+			secretIds = append(secretIds, secret.SecretID)
 		}
 
 		var gpuConfig *pb.GPUConfig

--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -214,7 +214,7 @@ func (s *sandboxServiceImpl) Create(ctx context.Context, app *App, image *Image,
 
 	mergedParams := *params
 	mergedParams.Secrets = mergedSecrets
-	mergedParams.Env = nil
+	mergedParams.Env = nil // nil'ing Env just to clarify it's not needed anymore
 
 	req, err := buildSandboxCreateRequestProto(app.AppID, image.ImageID, mergedParams)
 	if err != nil {
@@ -413,7 +413,7 @@ func (sb *Sandbox) Exec(ctx context.Context, command []string, params *SandboxEx
 
 	mergedParams := *params
 	mergedParams.Secrets = mergedSecrets
-	mergedParams.Env = nil
+	mergedParams.Env = nil // nil'ing Env just to clarify it's not needed anymore
 
 	req, err := buildContainerExecRequestProto(sb.taskID, command, mergedParams)
 	if err != nil {

--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -54,7 +54,7 @@ type SandboxCreateParams struct {
 }
 
 // buildSandboxCreateRequestProto builds a SandboxCreateRequest proto from options.
-func buildSandboxCreateRequestProto(appID, imageID string, params SandboxCreateParams, envSecret *Secret) (*pb.SandboxCreateRequest, error) {
+func buildSandboxCreateRequestProto(appID, imageID string, params SandboxCreateParams) (*pb.SandboxCreateRequest, error) {
 	gpuConfig, err := parseGPUConfig(params.GPU)
 	if err != nil {
 		return nil, err
@@ -127,12 +127,6 @@ func buildSandboxCreateRequestProto(appID, imageID string, params SandboxCreateP
 		if secret != nil {
 			secretIds = append(secretIds, secret.SecretID)
 		}
-	}
-	if (len(params.Env) > 0) != (envSecret != nil) {
-		return nil, fmt.Errorf("internal error: Env and envSecret must both be provided or neither be provided")
-	}
-	if envSecret != nil {
-		secretIds = append(secretIds, envSecret.SecretID)
 	}
 
 	var networkAccess *pb.NetworkAccess
@@ -213,15 +207,16 @@ func (s *sandboxServiceImpl) Create(ctx context.Context, app *App, image *Image,
 		return nil, err
 	}
 
-	var envSecret *Secret
-	if len(params.Env) > 0 {
-		envSecret, err = s.client.Secrets.FromMap(ctx, params.Env, nil)
-		if err != nil {
-			return nil, err
-		}
+	mergedSecrets, err := mergeEnvIntoSecrets(ctx, s.client, &params.Env, &params.Secrets)
+	if err != nil {
+		return nil, err
 	}
 
-	req, err := buildSandboxCreateRequestProto(app.AppID, image.ImageID, *params, envSecret)
+	mergedParams := *params
+	mergedParams.Secrets = mergedSecrets
+	mergedParams.Env = nil
+
+	req, err := buildSandboxCreateRequestProto(app.AppID, image.ImageID, mergedParams)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +369,7 @@ type SandboxExecParams struct {
 }
 
 // buildContainerExecRequestProto builds a ContainerExecRequest proto from command and options.
-func buildContainerExecRequestProto(taskID string, command []string, params SandboxExecParams, envSecret *Secret) (*pb.ContainerExecRequest, error) {
+func buildContainerExecRequestProto(taskID string, command []string, params SandboxExecParams) (*pb.ContainerExecRequest, error) {
 	var workdir *string
 	if params.Workdir != "" {
 		workdir = &params.Workdir
@@ -384,12 +379,6 @@ func buildContainerExecRequestProto(taskID string, command []string, params Sand
 		if secret != nil {
 			secretIds = append(secretIds, secret.SecretID)
 		}
-	}
-	if (len(params.Env) > 0) != (envSecret != nil) {
-		return nil, fmt.Errorf("internal error: Env and envSecret must both be provided or neither be provided")
-	}
-	if envSecret != nil {
-		secretIds = append(secretIds, envSecret.SecretID)
 	}
 
 	var ptyInfo *pb.PTYInfo
@@ -417,16 +406,16 @@ func (sb *Sandbox) Exec(ctx context.Context, command []string, params *SandboxEx
 		return nil, err
 	}
 
-	var envSecret *Secret
-	if len(params.Env) > 0 {
-		var err error
-		envSecret, err = sb.client.Secrets.FromMap(ctx, params.Env, nil)
-		if err != nil {
-			return nil, err
-		}
+	mergedSecrets, err := mergeEnvIntoSecrets(ctx, sb.client, &params.Env, &params.Secrets)
+	if err != nil {
+		return nil, err
 	}
 
-	req, err := buildContainerExecRequestProto(sb.taskID, command, *params, envSecret)
+	mergedParams := *params
+	mergedParams.Secrets = mergedSecrets
+	mergedParams.Env = nil
+
+	req, err := buildContainerExecRequestProto(sb.taskID, command, mergedParams)
 	if err != nil {
 		return nil, err
 	}

--- a/modal-go/sandbox_test.go
+++ b/modal-go/sandbox_test.go
@@ -10,7 +10,7 @@ import (
 func TestSandboxCreateRequestProto_WithoutPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateParams{}, nil)
+	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateParams{})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	definition := req.GetDefinition()
@@ -23,7 +23,7 @@ func TestSandboxCreateRequestProto_WithPTY(t *testing.T) {
 
 	req, err := buildSandboxCreateRequestProto("app-123", "img-456", SandboxCreateParams{
 		PTY: true,
-	}, nil)
+	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	definition := req.GetDefinition()
@@ -36,55 +36,9 @@ func TestSandboxCreateRequestProto_WithPTY(t *testing.T) {
 	g.Expect(ptyInfo.GetPtyType()).To(gomega.Equal(pb.PTYInfo_PTY_TYPE_SHELL))
 }
 
-func TestSandboxCreateRequestProto_MergesEnvAndSecrets(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	secret := &Secret{SecretID: "test-secret-1"}
-
-	envVars := map[string]string{"B": "2"}
-	envSecret := &Secret{SecretID: "test-env-secret"}
-
-	_, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{
-		Env: envVars,
-	}, nil)
-	g.Expect(err).Should(gomega.HaveOccurred())
-	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
-
-	_, err = buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{}, envSecret)
-	g.Expect(err).Should(gomega.HaveOccurred())
-	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
-
-	req, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{
-		Env:     envVars,
-		Secrets: []*Secret{secret},
-	}, envSecret)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	definition := req.GetDefinition()
-	g.Expect(definition.GetSecretIds()).To(gomega.HaveLen(2))
-	g.Expect(definition.GetSecretIds()).To(gomega.ContainElement(secret.SecretID))
-	g.Expect(definition.GetSecretIds()).To(gomega.ContainElement(envSecret.SecretID))
-}
-
-func TestSandboxCreateRequestProto_WithOnlyEnvParameter(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	envVars := map[string]string{"B": "2", "C": "3"}
-	envSecret := &Secret{SecretID: "test-env-secret"}
-
-	req, err := buildSandboxCreateRequestProto("ap", "im", SandboxCreateParams{
-		Env: envVars,
-	}, envSecret)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	definition := req.GetDefinition()
-	g.Expect(definition.GetSecretIds()).To(gomega.HaveLen(1))
-	g.Expect(definition.GetSecretIds()).To(gomega.ContainElement(envSecret.SecretID))
-}
-
 func TestContainerExecProto_WithoutPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
-	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecParams{}, nil)
+	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecParams{})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	ptyInfo := req.GetPtyInfo()
@@ -95,7 +49,7 @@ func TestContainerExecProto_WithPTY(t *testing.T) {
 	g := gomega.NewWithT(t)
 	req, err := buildContainerExecRequestProto("task-123", []string{"bash"}, SandboxExecParams{
 		PTY: true,
-	}, nil)
+	})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	ptyInfo := req.GetPtyInfo()
@@ -107,48 +61,4 @@ func TestContainerExecProto_WithPTY(t *testing.T) {
 	g.Expect(ptyInfo.GetEnvColorterm()).To(gomega.Equal("truecolor"))
 	g.Expect(ptyInfo.GetPtyType()).To(gomega.Equal(pb.PTYInfo_PTY_TYPE_SHELL))
 	g.Expect(ptyInfo.GetNoTerminateOnIdleStdin()).To(gomega.BeTrue())
-}
-
-func TestContainerExecRequestProto_MergesEnvAndSecrets(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	secret := &Secret{SecretID: "test-secret-1"}
-
-	envVars := map[string]string{"B": "2"}
-	envSecret := &Secret{SecretID: "test-env-secret"}
-
-	_, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{
-		Env: envVars,
-	}, nil)
-	g.Expect(err).Should(gomega.HaveOccurred())
-	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
-
-	_, err = buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{}, envSecret)
-	g.Expect(err).Should(gomega.HaveOccurred())
-	g.Expect(err.Error()).Should(gomega.ContainSubstring("internal error: Env and envSecret must both be provided or neither be provided"))
-
-	req, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{
-		Env:     envVars,
-		Secrets: []*Secret{secret},
-	}, envSecret)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	g.Expect(req.GetSecretIds()).To(gomega.HaveLen(2))
-	g.Expect(req.GetSecretIds()).To(gomega.ContainElement(secret.SecretID))
-	g.Expect(req.GetSecretIds()).To(gomega.ContainElement(envSecret.SecretID))
-}
-
-func TestContainerExecRequestProto_WithOnlyEnvParameter(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	envVars := map[string]string{"B": "2"}
-	envSecret := &Secret{SecretID: "test-env-secret"}
-
-	req, err := buildContainerExecRequestProto("ta", []string{"echo", "hello"}, SandboxExecParams{
-		Env: envVars,
-	}, envSecret)
-	g.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	g.Expect(req.GetSecretIds()).To(gomega.HaveLen(1))
-	g.Expect(req.GetSecretIds()).To(gomega.ContainElement(envSecret.SecretID))
 }

--- a/modal-go/secret_test.go
+++ b/modal-go/secret_test.go
@@ -1,0 +1,97 @@
+package modal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+type mockSecretService struct{ SecretService }
+
+func (m *mockSecretService) FromMap(ctx context.Context, keyValuePairs map[string]string, params *SecretFromMapParams) (*Secret, error) {
+	return &Secret{SecretID: "st-mock-env"}, nil
+}
+
+func TestMergeEnvIntoSecrets_WithEnvAndExistingSecrets(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	mockClient := &Client{Secrets: &mockSecretService{}}
+
+	env := map[string]string{"B": "2", "C": "3"}
+	existingSecret := &Secret{SecretID: "st-existing"}
+	secrets := []*Secret{existingSecret}
+
+	result, err := mergeEnvIntoSecrets(ctx, mockClient, &env, &secrets)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveLen(2))
+	g.Expect(result[0]).To(gomega.Equal(existingSecret))
+	g.Expect(result[1].SecretID).To(gomega.Equal("st-mock-env"))
+}
+
+func TestMergeEnvIntoSecrets_WithOnlyEnv(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	mockClient := &Client{Secrets: &mockSecretService{}}
+
+	env := map[string]string{"B": "2", "C": "3"}
+
+	result, err := mergeEnvIntoSecrets(ctx, mockClient, &env, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveLen(1))
+	g.Expect(result[0].SecretID).To(gomega.Equal("st-mock-env"))
+}
+
+func TestMergeEnvIntoSecrets_WithEmptyEnvReturnsExistingSecrets(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	existingSecret := &Secret{SecretID: "st-existing"}
+	env := map[string]string{}
+	secrets := []*Secret{existingSecret}
+
+	result, err := mergeEnvIntoSecrets(ctx, &Client{}, &env, &secrets)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveLen(1))
+	g.Expect(result[0]).To(gomega.Equal(existingSecret))
+}
+
+func TestMergeEnvIntoSecrets_WithNilEnvReturnsExistingSecrets(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	existingSecret := &Secret{SecretID: "st-existing"}
+	secrets := []*Secret{existingSecret}
+
+	result, err := mergeEnvIntoSecrets(ctx, &Client{}, nil, &secrets)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveLen(1))
+	g.Expect(result[0]).To(gomega.Equal(existingSecret))
+}
+
+func TestMergeEnvIntoSecrets_WithOnlyExistingSecrets(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	secret1 := &Secret{SecretID: "st-secret1"}
+	secret2 := &Secret{SecretID: "st-secret2"}
+	secrets := []*Secret{secret1, secret2}
+
+	result, err := mergeEnvIntoSecrets(ctx, &Client{}, nil, &secrets)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveLen(2))
+	g.Expect(result[0]).To(gomega.Equal(secret1))
+	g.Expect(result[1]).To(gomega.Equal(secret2))
+}
+
+func TestMergeEnvIntoSecrets_WithNoEnvAndNoSecretsReturnsEmptyArray(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	result, err := mergeEnvIntoSecrets(ctx, &Client{}, nil, nil)
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.HaveLen(0))
+	g.Expect(result).To(gomega.BeNil())
+}

--- a/modal-js/src/cls.ts
+++ b/modal-js/src/cls.ts
@@ -14,7 +14,7 @@ import { getDefaultClient, type ModalClient } from "./client";
 import { Function_ } from "./function";
 import { parseGpuConfig } from "./app";
 import type { Secret } from "./secret";
-import { mergeEnvAndSecrets } from "./secret";
+import { mergeEnvIntoSecrets } from "./secret";
 import { Retries, parseRetries } from "./retries";
 import type { Volume } from "./volume";
 
@@ -221,10 +221,18 @@ export class Cls {
 
   /** Bind parameters to the Cls function. */
   async #bindParameters(parameters: Record<string, any>): Promise<string> {
-    const serializedParams = encodeParameterSet(this.#schema, parameters);
-    const functionOptions = await buildFunctionOptionsProto(
-      this.#serviceOptions,
+    const mergedSecrets = await mergeEnvIntoSecrets(
+      this.#client,
+      this.#serviceOptions?.env,
+      this.#serviceOptions?.secrets,
     );
+    const mergedOptions = mergeServiceOptions(this.#serviceOptions, {
+      secrets: mergedSecrets,
+      env: undefined,
+    });
+
+    const serializedParams = encodeParameterSet(this.#schema, parameters);
+    const functionOptions = await buildFunctionOptionsProto(mergedOptions);
     const bindResp = await this.#client.cpClient.functionBindParams({
       functionId: this.#serviceFunctionId,
       serializedParams,
@@ -275,8 +283,7 @@ async function buildFunctionOptionsProto(
         }
       : undefined;
 
-  const mergedSecrets = await mergeEnvAndSecrets(o.env, o.secrets);
-  const secretIds = mergedSecrets.map((s) => s.secretId);
+  const secretIds = (o.secrets || []).map((s) => s.secretId);
 
   const volumeMounts: VolumeMount[] = o.volumes
     ? Object.entries(o.volumes).map(([mountPath, volume]) => ({

--- a/modal-js/src/cls.ts
+++ b/modal-js/src/cls.ts
@@ -228,7 +228,7 @@ export class Cls {
     );
     const mergedOptions = mergeServiceOptions(this.#serviceOptions, {
       secrets: mergedSecrets,
-      env: undefined,
+      env: undefined, // setting env to undefined just to clarify it's not needed anymore
     });
 
     const serializedParams = encodeParameterSet(this.#schema, parameters);

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -8,7 +8,7 @@ import {
 } from "../proto/modal_proto/api";
 import { getDefaultClient, type ModalClient } from "./client";
 import { App, parseGpuConfig } from "./app";
-import { Secret, mergeEnvAndSecrets } from "./secret";
+import { Secret, mergeEnvIntoSecrets } from "./secret";
 import { ClientError } from "nice-grpc";
 import { Status } from "nice-grpc";
 import { NotFoundError, InvalidError } from "./errors";
@@ -269,7 +269,12 @@ export class Image {
     for (let i = 0; i < this.#layers.length; i++) {
       const layer = this.#layers[i];
 
-      const mergedSecrets = await mergeEnvAndSecrets(layer.env, layer.secrets);
+      const mergedSecrets = await mergeEnvIntoSecrets(
+        this.#client,
+        layer.env,
+        layer.secrets,
+      );
+
       const secretIds = mergedSecrets.map((secret) => secret.secretId);
       const gpuConfig = layer.gpuConfig;
 

--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -34,7 +34,7 @@ import {
   toModalReadStream,
   toModalWriteStream,
 } from "./streams";
-import { type Secret, mergeEnvAndSecrets } from "./secret";
+import { type Secret, mergeEnvIntoSecrets } from "./secret";
 import {
   InvalidError,
   NotFoundError,
@@ -201,8 +201,7 @@ export async function buildSandboxCreateRequestProto(
     );
   }
 
-  const mergedSecrets = await mergeEnvAndSecrets(params.env, params.secrets);
-  const secretIds = mergedSecrets.map((secret) => secret.secretId);
+  const secretIds = (params.secrets || []).map((secret) => secret.secretId);
 
   let networkAccess: NetworkAccess;
   if (params.blockNetwork) {
@@ -286,10 +285,21 @@ export class SandboxService {
   ): Promise<Sandbox> {
     await image.build(app);
 
+    const mergedSecrets = await mergeEnvIntoSecrets(
+      this.#client,
+      params.env,
+      params.secrets,
+    );
+    const mergedParams = {
+      ...params,
+      secrets: mergedSecrets,
+      env: undefined,
+    };
+
     const createReq = await buildSandboxCreateRequestProto(
       app.appId,
       image.imageId,
-      params,
+      mergedParams,
     );
     let createResp;
     try {
@@ -487,8 +497,7 @@ export async function buildContainerExecRequestProto(
   command: string[],
   params?: SandboxExecParams,
 ): Promise<ContainerExecRequest> {
-  const mergedSecrets = await mergeEnvAndSecrets(params?.env, params?.secrets);
-  const secretIds = mergedSecrets.map((secret) => secret.secretId);
+  const secretIds = (params?.secrets || []).map((secret) => secret.secretId);
 
   let ptyInfo: PTYInfo | undefined;
   if (params?.pty) {
@@ -639,7 +648,22 @@ export class Sandbox {
   ): Promise<ContainerProcess> {
     const taskId = await this.#getTaskId();
 
-    const req = await buildContainerExecRequestProto(taskId, command, params);
+    const mergedSecrets = await mergeEnvIntoSecrets(
+      this.#client,
+      params?.env,
+      params?.secrets,
+    );
+    const mergedParams = {
+      ...params,
+      secrets: mergedSecrets,
+      env: undefined,
+    };
+
+    const req = await buildContainerExecRequestProto(
+      taskId,
+      command,
+      mergedParams,
+    );
     const resp = await this.#client.cpClient.containerExec(req);
 
     return new ContainerProcess(this.#client, resp.execId, params);

--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -293,7 +293,7 @@ export class SandboxService {
     const mergedParams = {
       ...params,
       secrets: mergedSecrets,
-      env: undefined,
+      env: undefined, // setting env to undefined just to clarify it's not needed anymore
     };
 
     const createReq = await buildSandboxCreateRequestProto(
@@ -656,7 +656,7 @@ export class Sandbox {
     const mergedParams = {
       ...params,
       secrets: mergedSecrets,
-      env: undefined,
+      env: undefined, // setting env to undefined just to clarify it's not needed anymore
     };
 
     const req = await buildContainerExecRequestProto(

--- a/modal-js/src/secret.ts
+++ b/modal-js/src/secret.ts
@@ -1,4 +1,4 @@
-import { getDefaultClient, ModalClient } from "./client";
+import { getDefaultClient, type ModalClient } from "./client";
 import { ClientError, Status } from "nice-grpc";
 import { InvalidError, NotFoundError } from "./errors";
 import { ObjectCreationType } from "../proto/modal_proto/api";
@@ -110,13 +110,14 @@ export class Secret {
   }
 }
 
-export async function mergeEnvAndSecrets(
+export async function mergeEnvIntoSecrets(
+  client: ModalClient,
   env?: Record<string, string>,
   secrets?: Secret[],
 ): Promise<Secret[]> {
   const result = [...(secrets || [])];
   if (env && Object.keys(env).length > 0) {
-    result.push(await getDefaultClient().secrets.fromObject(env));
+    result.push(await client.secrets.fromObject(env));
   }
   return result;
 }

--- a/modal-js/test/legacy/sandbox.test.ts
+++ b/modal-js/test/legacy/sandbox.test.ts
@@ -526,34 +526,6 @@ test("buildContainerExecRequestProto with PTY", async () => {
   expect(ptyInfo.noTerminateOnIdleStdin).toBe(true);
 });
 
-test("buildSandboxCreateRequestProto merges env and secrets", async () => {
-  const secret = await Secret.fromObject({ A: "1" });
-
-  const req = await buildSandboxCreateRequestProto("ap", "im", {
-    env: { B: "2" },
-    secrets: [secret],
-  });
-
-  expect(req.definition!.secretIds).toHaveLength(2);
-  expect(req.definition!.secretIds).toContain(secret.secretId);
-});
-
-test("buildSandboxCreateRequestProto with only env parameter", async () => {
-  const req = await buildSandboxCreateRequestProto("ap", "im", {
-    env: { B: "2", C: "3" },
-  });
-
-  expect(req.definition!.secretIds).toHaveLength(1);
-});
-
-test("buildSandboxCreateRequestProto with empty env object does not create secret", async () => {
-  const req = await buildSandboxCreateRequestProto("ap", "im", {
-    env: {},
-  });
-
-  expect(req.definition!.secretIds).toHaveLength(0);
-});
-
 test("buildSandboxCreateRequestProto without PTY", async () => {
   const req = await buildSandboxCreateRequestProto("app-123", "img-456");
 
@@ -574,32 +546,4 @@ test("buildSandboxCreateRequestProto with PTY", async () => {
   expect(ptyInfo.envTerm).toBe("xterm-256color");
   expect(ptyInfo.envColorterm).toBe("truecolor");
   expect(ptyInfo.ptyType).toBe(PTYInfo_PTYType.PTY_TYPE_SHELL);
-});
-
-test("buildContainerExecRequestProto merges env and secrets", async () => {
-  const secret = await Secret.fromObject({ A: "1" });
-
-  const req = await buildContainerExecRequestProto("ta", ["echo", "hello"], {
-    env: { B: "2" },
-    secrets: [secret],
-  });
-
-  expect(req.secretIds).toHaveLength(2);
-  expect(req.secretIds).toContain(secret.secretId);
-});
-
-test("buildContainerExecRequestProto with only env parameter", async () => {
-  const req = await buildContainerExecRequestProto("ta", ["echo", "hello"], {
-    env: { B: "2" },
-  });
-
-  expect(req.secretIds).toHaveLength(1);
-});
-
-test("buildContainerExecRequestProto with empty env object does not create secret", async () => {
-  const req = await buildContainerExecRequestProto("ta", ["echo", "hello"], {
-    env: {},
-  });
-
-  expect(req.secretIds).toHaveLength(0);
 });

--- a/modal-js/test/sandbox.test.ts
+++ b/modal-js/test/sandbox.test.ts
@@ -565,34 +565,6 @@ test("buildContainerExecRequestProto with PTY", async () => {
   expect(ptyInfo.noTerminateOnIdleStdin).toBe(true);
 });
 
-test("buildSandboxCreateRequestProto merges env and secrets", async () => {
-  const secret = await tc.secrets.fromObject({ A: "1" });
-
-  const req = await buildSandboxCreateRequestProto("ap", "im", {
-    env: { B: "2" },
-    secrets: [secret],
-  });
-
-  expect(req.definition!.secretIds).toHaveLength(2);
-  expect(req.definition!.secretIds).toContain(secret.secretId);
-});
-
-test("buildSandboxCreateRequestProto with only env parameter", async () => {
-  const req = await buildSandboxCreateRequestProto("ap", "im", {
-    env: { B: "2", C: "3" },
-  });
-
-  expect(req.definition!.secretIds).toHaveLength(1);
-});
-
-test("buildSandboxCreateRequestProto with empty env object does not create secret", async () => {
-  const req = await buildSandboxCreateRequestProto("ap", "im", {
-    env: {},
-  });
-
-  expect(req.definition!.secretIds).toHaveLength(0);
-});
-
 test("buildSandboxCreateRequestProto without PTY", async () => {
   const req = await buildSandboxCreateRequestProto("app-123", "img-456");
 
@@ -613,32 +585,4 @@ test("buildSandboxCreateRequestProto with PTY", async () => {
   expect(ptyInfo.envTerm).toBe("xterm-256color");
   expect(ptyInfo.envColorterm).toBe("truecolor");
   expect(ptyInfo.ptyType).toBe(PTYInfo_PTYType.PTY_TYPE_SHELL);
-});
-
-test("buildContainerExecRequestProto merges env and secrets", async () => {
-  const secret = await tc.secrets.fromObject({ A: "1" });
-
-  const req = await buildContainerExecRequestProto("ta", ["echo", "hello"], {
-    env: { B: "2" },
-    secrets: [secret],
-  });
-
-  expect(req.secretIds).toHaveLength(2);
-  expect(req.secretIds).toContain(secret.secretId);
-});
-
-test("buildContainerExecRequestProto with only env parameter", async () => {
-  const req = await buildContainerExecRequestProto("ta", ["echo", "hello"], {
-    env: { B: "2" },
-  });
-
-  expect(req.secretIds).toHaveLength(1);
-});
-
-test("buildContainerExecRequestProto with empty env object does not create secret", async () => {
-  const req = await buildContainerExecRequestProto("ta", ["echo", "hello"], {
-    env: {},
-  });
-
-  expect(req.secretIds).toHaveLength(0);
 });

--- a/modal-js/test/secret.test.ts
+++ b/modal-js/test/secret.test.ts
@@ -1,5 +1,6 @@
 import { tc } from "../test-support/test-client";
 import { expect, test } from "vitest";
+import { mergeEnvIntoSecrets } from "../src/secret";
 
 test("SecretFromName", async () => {
   const secret = await tc.secrets.fromName("libmodal-test-secret");
@@ -51,4 +52,61 @@ test("SecretFromObjectInvalid", async () => {
   await expect(tc.secrets.fromObject({ key: 123 })).rejects.toThrowError(
     /entries must be an object mapping string keys to string values/,
   );
+});
+
+test("mergeEnvIntoSecrets merges env with existing secrets", async () => {
+  const existingSecret = await tc.secrets.fromObject({ A: "1" });
+  const env = { B: "2", C: "3" };
+
+  const result = await mergeEnvIntoSecrets(tc, env, [existingSecret]);
+
+  expect(result).toHaveLength(2);
+  expect(result[0]).toBe(existingSecret);
+  expect(result[1].secretId).toMatch(/^st-/);
+});
+
+test("mergeEnvIntoSecrets with only env parameter", async () => {
+  const env = { B: "2", C: "3" };
+
+  const result = await mergeEnvIntoSecrets(tc, env);
+
+  expect(result).toHaveLength(1);
+  expect(result[0].secretId).toMatch(/^st-/);
+});
+
+test("mergeEnvIntoSecrets with empty env object returns existing secrets", async () => {
+  const existingSecret = await tc.secrets.fromObject({ A: "1" });
+  const env = {};
+
+  const result = await mergeEnvIntoSecrets(tc, env, [existingSecret]);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(existingSecret);
+});
+
+test("mergeEnvIntoSecrets with undefined env returns existing secrets", async () => {
+  const existingSecret = await tc.secrets.fromObject({ A: "1" });
+
+  const result = await mergeEnvIntoSecrets(tc, undefined, [existingSecret]);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(existingSecret);
+});
+
+test("mergeEnvIntoSecrets with only existing secrets", async () => {
+  const secret1 = await tc.secrets.fromObject({ A: "1" });
+  const secret2 = await tc.secrets.fromObject({ B: "2" });
+
+  const result = await mergeEnvIntoSecrets(tc, undefined, [secret1, secret2]);
+
+  expect(result).toHaveLength(2);
+  expect(result[0]).toBe(secret1);
+  expect(result[1]).toBe(secret2);
+});
+
+test("mergeEnvIntoSecrets with no env and no secrets returns empty array", async () => {
+  const result = await mergeEnvIntoSecrets(tc);
+
+  expect(result).toHaveLength(0);
+  expect(result).toEqual([]);
 });


### PR DESCRIPTION
By creating the env Secret in `Image.build`/`Cls.instantiate`/`Sandbox.create`/`Sandbox.exec` where we already have access to a client and `ctx` the implementation and tests become a little less awkward. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Merge `env` into `secrets` at call sites (Cls/Image/Sandbox) and drop `envSecret` plumbing, simplifying proto builders and updating tests.
> 
> - **Core (Go)**
>   - Introduce `mergeEnvIntoSecrets` in `modal-go/secret.go` to convert `env` maps into a Secret and append to `secrets`.
>   - Update `Cls.Instance`/`bindParameters`, `Image.Build`, `Sandbox.Create`/`Exec` to use merged secrets and stop passing separate `env`.
>   - Change `buildFunctionOptionsProto` and Sandbox proto builders to accept only options/secrets (remove `envSecret` param) and compute `secretIds` from merged secrets.
> - **Core (JS/TS)**
>   - Add `mergeEnvIntoSecrets(client, env, secrets)` and use it in `cls`, `image`, `sandbox` flows; remove reliance on global client.
>   - Build function/sandbox/exec requests using merged `secrets` only; drop implicit env handling inside builders.
> - **Tests**
>   - Remove tests asserting paired `env`/`envSecret` behavior; add tests for `mergeEnvIntoSecrets` and adjust existing tests to expect `secretIds` derived solely from `secrets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6d5bb54864daaf8b562d92a53d5ce515445f021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->