### PR TITLE
Refactor client services to interfaces

### DIFF
--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -12,7 +12,11 @@ import (
 )
 
 // AppService provides App related operations.
-type AppService struct{ client *Client }
+type AppService interface {
+	FromName(ctx context.Context, name string, params *AppFromNameParams) (*App, error)
+}
+
+type appServiceImpl struct{ client *Client }
 
 // App references a deployed Modal App.
 type App struct {
@@ -55,7 +59,7 @@ type AppFromNameParams struct {
 }
 
 // FromName references an App with a given name, creating a new App if necessary.
-func (s *AppService) FromName(ctx context.Context, name string, params *AppFromNameParams) (*App, error) {
+func (s *appServiceImpl) FromName(ctx context.Context, name string, params *AppFromNameParams) (*App, error) {
 	if params == nil {
 		params = &AppFromNameParams{}
 	}

--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -26,17 +26,17 @@ import (
 // Client exposes services for interacting with Modal resources.
 // You should not instantiate it directly, and instead use [NewClient]/[NewClientWithOptions].
 type Client struct {
-	Apps              *AppService
-	CloudBucketMounts *CloudBucketMountService
-	Cls               *ClsService
-	Functions         *FunctionService
-	FunctionCalls     *FunctionCallService
-	Images            *ImageService
-	Proxies           *ProxyService
-	Queues            *QueueService
-	Sandboxes         *SandboxService
-	Secrets           *SecretService
-	Volumes           *VolumeService
+	Apps              AppService
+	CloudBucketMounts CloudBucketMountService
+	Cls               ClsService
+	Functions         FunctionService
+	FunctionCalls     FunctionCallService
+	Images            ImageService
+	Proxies           ProxyService
+	Queues            QueueService
+	Sandboxes         SandboxService
+	Secrets           SecretService
+	Volumes           VolumeService
 
 	config    config
 	profile   Profile
@@ -105,17 +105,17 @@ func NewClientWithOptions(params *ClientParams) (*Client, error) {
 		return nil, fmt.Errorf("failed to create control plane client: %w", err)
 	}
 
-	c.Apps = &AppService{client: c}
-	c.CloudBucketMounts = &CloudBucketMountService{client: c}
-	c.Cls = &ClsService{client: c}
-	c.Functions = &FunctionService{client: c}
-	c.FunctionCalls = &FunctionCallService{client: c}
-	c.Images = &ImageService{client: c}
-	c.Proxies = &ProxyService{client: c}
-	c.Queues = &QueueService{client: c}
-	c.Sandboxes = &SandboxService{client: c}
-	c.Secrets = &SecretService{client: c}
-	c.Volumes = &VolumeService{client: c}
+	c.Apps = &appServiceImpl{client: c}
+	c.CloudBucketMounts = &cloudBucketMountServiceImpl{client: c}
+	c.Cls = &clsServiceImpl{client: c}
+	c.Functions = &functionServiceImpl{client: c}
+	c.FunctionCalls = &functionCallServiceImpl{client: c}
+	c.Images = &imageServiceImpl{client: c}
+	c.Proxies = &proxyServiceImpl{client: c}
+	c.Queues = &queueServiceImpl{client: c}
+	c.Sandboxes = &sandboxServiceImpl{client: c}
+	c.Secrets = &secretServiceImpl{client: c}
+	c.Volumes = &volumeServiceImpl{client: c}
 
 	return c, nil
 }

--- a/modal-go/cloud_bucket_mount.go
+++ b/modal-go/cloud_bucket_mount.go
@@ -9,7 +9,11 @@ import (
 )
 
 // CloudBucketMountService provides CloudBucketMount related operations.
-type CloudBucketMountService struct{ client *Client }
+type CloudBucketMountService interface {
+	New(bucketName string, params *CloudBucketMountParams) (*CloudBucketMount, error)
+}
+
+type cloudBucketMountServiceImpl struct{ client *Client }
 
 // CloudBucketMount provides access to cloud storage buckets within Modal Functions.
 type CloudBucketMount struct {
@@ -33,7 +37,7 @@ type CloudBucketMountParams struct {
 }
 
 // New creates a new CloudBucketMount.
-func (s *CloudBucketMountService) New(bucketName string, params *CloudBucketMountParams) (*CloudBucketMount, error) {
+func (s *cloudBucketMountServiceImpl) New(bucketName string, params *CloudBucketMountParams) (*CloudBucketMount, error) {
 	if params == nil {
 		params = &CloudBucketMountParams{}
 	}

--- a/modal-go/cloud_bucket_mount_test.go
+++ b/modal-go/cloud_bucket_mount_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newTestMount(bucketName string, params *CloudBucketMountParams) (*CloudBucketMount, error) {
-	return (&CloudBucketMountService{}).New(bucketName, params)
+	return (&cloudBucketMountServiceImpl{}).New(bucketName, params)
 }
 
 func TestNewCloudBucketMount_MinimalOptions(t *testing.T) {

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -13,7 +13,11 @@ import (
 )
 
 // ClsService provides Cls related operations.
-type ClsService struct{ client *Client }
+type ClsService interface {
+	FromName(ctx context.Context, appName string, name string, params *ClsFromNameParams) (*Cls, error)
+}
+
+type clsServiceImpl struct{ client *Client }
 
 // ClsWithOptionsParams represents runtime options for a Modal Cls.
 type ClsWithOptionsParams struct {
@@ -79,7 +83,7 @@ type ClsFromNameParams struct {
 }
 
 // FromName references a Cls from a deployed App by its name.
-func (s *ClsService) FromName(ctx context.Context, appName string, name string, params *ClsFromNameParams) (*Cls, error) {
+func (s *clsServiceImpl) FromName(ctx context.Context, appName string, name string, params *ClsFromNameParams) (*Cls, error) {
 	if params == nil {
 		params = &ClsFromNameParams{}
 	}

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -20,7 +20,11 @@ import (
 )
 
 // FunctionService provides Function related operations.
-type FunctionService struct{ client *Client }
+type FunctionService interface {
+	FromName(ctx context.Context, appName string, name string, params *FunctionFromNameParams) (*Function, error)
+}
+
+type functionServiceImpl struct{ client *Client }
 
 // From: modal/_utils/blob_utils.py
 const maxObjectSizeBytes int = 2 * 1024 * 1024 // 2 MiB
@@ -66,7 +70,7 @@ type FunctionFromNameParams struct {
 }
 
 // FromName references a Function from a deployed App by its name.
-func (s *FunctionService) FromName(ctx context.Context, appName string, name string, params *FunctionFromNameParams) (*Function, error) {
+func (s *functionServiceImpl) FromName(ctx context.Context, appName string, name string, params *FunctionFromNameParams) (*Function, error) {
 	if params == nil {
 		params = &FunctionFromNameParams{}
 	}

--- a/modal-go/function_call.go
+++ b/modal-go/function_call.go
@@ -9,7 +9,11 @@ import (
 )
 
 // FunctionCallService provides FunctionCall related operations.
-type FunctionCallService struct{ client *Client }
+type FunctionCallService interface {
+	FromID(ctx context.Context, functionCallID string) (*FunctionCall, error)
+}
+
+type functionCallServiceImpl struct{ client *Client }
 
 // FunctionCall references a Modal Function Call. Function Calls are
 // Function invocations with a given input. They can be consumed
@@ -21,7 +25,7 @@ type FunctionCall struct {
 }
 
 // FromID looks up a FunctionCall by ID.
-func (s *FunctionCallService) FromID(ctx context.Context, functionCallID string) (*FunctionCall, error) {
+func (s *functionCallServiceImpl) FromID(ctx context.Context, functionCallID string) (*FunctionCall, error) {
 	functionCall := FunctionCall{
 		FunctionCallID: functionCallID,
 		client:         s.client,

--- a/modal-go/proxy.go
+++ b/modal-go/proxy.go
@@ -10,7 +10,11 @@ import (
 )
 
 // ProxyService provides Proxy related operations.
-type ProxyService struct{ client *Client }
+type ProxyService interface {
+	FromName(ctx context.Context, name string, params *ProxyFromNameParams) (*Proxy, error)
+}
+
+type proxyServiceImpl struct{ client *Client }
 
 // Proxy represents a Modal Proxy.
 type Proxy struct {
@@ -23,7 +27,7 @@ type ProxyFromNameParams struct {
 }
 
 // FromName references a modal.Proxy by its name.
-func (s *ProxyService) FromName(ctx context.Context, name string, params *ProxyFromNameParams) (*Proxy, error) {
+func (s *proxyServiceImpl) FromName(ctx context.Context, name string, params *ProxyFromNameParams) (*Proxy, error) {
 	if params == nil {
 		params = &ProxyFromNameParams{}
 	}

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -14,7 +14,13 @@ import (
 )
 
 // QueueService provides Queue related operations.
-type QueueService struct{ client *Client }
+type QueueService interface {
+	Ephemeral(ctx context.Context, params *QueueEphemeralParams) (*Queue, error)
+	FromName(ctx context.Context, name string, params *QueueFromNameParams) (*Queue, error)
+	Delete(ctx context.Context, name string, params *QueueDeleteParams) error
+}
+
+type queueServiceImpl struct{ client *Client }
 
 const queueInitialPutBackoff = 100 * time.Millisecond
 const queueDefaultPartitionTTL = 24 * time.Hour
@@ -45,7 +51,7 @@ type QueueEphemeralParams struct {
 }
 
 // Ephemeral creates a nameless, temporary Queue, that persists until CloseEphemeral is called, or the process exits.
-func (s *QueueService) Ephemeral(ctx context.Context, params *QueueEphemeralParams) (*Queue, error) {
+func (s *queueServiceImpl) Ephemeral(ctx context.Context, params *QueueEphemeralParams) (*Queue, error) {
 	if params == nil {
 		params = &QueueEphemeralParams{}
 	}
@@ -93,7 +99,7 @@ type QueueFromNameParams struct {
 }
 
 // FromName references a named Queue, creating if necessary.
-func (s *QueueService) FromName(ctx context.Context, name string, params *QueueFromNameParams) (*Queue, error) {
+func (s *queueServiceImpl) FromName(ctx context.Context, name string, params *QueueFromNameParams) (*Queue, error) {
 	if params == nil {
 		params = &QueueFromNameParams{}
 	}
@@ -125,7 +131,7 @@ type QueueDeleteParams struct {
 }
 
 // Delete removes a Queue by name.
-func (s *QueueService) Delete(ctx context.Context, name string, params *QueueDeleteParams) error {
+func (s *queueServiceImpl) Delete(ctx context.Context, name string, params *QueueDeleteParams) error {
 	if params == nil {
 		params = &QueueDeleteParams{}
 	}

--- a/modal-go/secret.go
+++ b/modal-go/secret.go
@@ -7,7 +7,13 @@ import (
 )
 
 // SecretService provides Secret related operations.
-type SecretService struct{ client *Client }
+type SecretService interface {
+	FromName(ctx context.Context, name string, params *SecretFromNameParams) (*Secret, error)
+	FromMap(ctx context.Context, keyValuePairs map[string]string, params *SecretFromMapParams) (*Secret, error)
+}
+
+// secretServiceImpl is the real implementation of SecretService.
+type secretServiceImpl struct{ client *Client }
 
 // Secret represents a Modal Secret.
 type Secret struct {
@@ -22,7 +28,7 @@ type SecretFromNameParams struct {
 }
 
 // FromName references a Secret by its name.
-func (s *SecretService) FromName(ctx context.Context, name string, params *SecretFromNameParams) (*Secret, error) {
+func (s *secretServiceImpl) FromName(ctx context.Context, name string, params *SecretFromNameParams) (*Secret, error) {
 	if params == nil {
 		params = &SecretFromNameParams{}
 	}
@@ -46,7 +52,7 @@ type SecretFromMapParams struct {
 }
 
 // FromMap creates a Secret from a map of key-value pairs.
-func (s *SecretService) FromMap(ctx context.Context, keyValuePairs map[string]string, params *SecretFromMapParams) (*Secret, error) {
+func (s *secretServiceImpl) FromMap(ctx context.Context, keyValuePairs map[string]string, params *SecretFromMapParams) (*Secret, error) {
 	if params == nil {
 		params = &SecretFromMapParams{}
 	}

--- a/modal-go/volume.go
+++ b/modal-go/volume.go
@@ -10,7 +10,12 @@ import (
 )
 
 // VolumeService provides Volume related operations.
-type VolumeService struct{ client *Client }
+type VolumeService interface {
+	FromName(ctx context.Context, name string, params *VolumeFromNameParams) (*Volume, error)
+	Ephemeral(ctx context.Context, params *VolumeEphemeralParams) (*Volume, error)
+}
+
+type volumeServiceImpl struct{ client *Client }
 
 // Volume represents a Modal Volume that provides persistent storage.
 type Volume struct {
@@ -27,7 +32,7 @@ type VolumeFromNameParams struct {
 }
 
 // FromName references a Volume by its name.
-func (s *VolumeService) FromName(ctx context.Context, name string, params *VolumeFromNameParams) (*Volume, error) {
+func (s *volumeServiceImpl) FromName(ctx context.Context, name string, params *VolumeFromNameParams) (*Volume, error) {
 	if params == nil {
 		params = &VolumeFromNameParams{}
 	}
@@ -74,7 +79,7 @@ type VolumeEphemeralParams struct {
 }
 
 // Ephemeral creates a nameless, temporary Volume, that persists until CloseEphemeral is called, or the process exits.
-func (s *VolumeService) Ephemeral(ctx context.Context, params *VolumeEphemeralParams) (*Volume, error) {
+func (s *volumeServiceImpl) Ephemeral(ctx context.Context, params *VolumeEphemeralParams) (*Volume, error) {
 	if params == nil {
 		params = &VolumeEphemeralParams{}
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert all client services to interfaces with concrete *Impl implementations and update Client fields/initialization accordingly.
> 
> - **Core API**:
>   - Convert service types (`AppService`, `CloudBucketMountService`, `ClsService`, `FunctionService`, `FunctionCallService`, `ImageService`, `ProxyService`, `QueueService`, `SandboxService`, `SecretService`, `VolumeService`) into interfaces with explicit method contracts.
>   - Add concrete implementations (`appServiceImpl`, `cloudBucketMountServiceImpl`, `clsServiceImpl`, `functionServiceImpl`, `functionCallServiceImpl`, `imageServiceImpl`, `proxyServiceImpl`, `queueServiceImpl`, `sandboxServiceImpl`, `secretServiceImpl`, `volumeServiceImpl`) and move method receivers to these.
> - **Client wiring**:
>   - Change `Client` fields from pointers to concrete services to interface types and instantiate with new `*Impl` structs in `NewClientWithOptions`.
> - **Tests**:
>   - Update test construction to use `cloudBucketMountServiceImpl` in `cloud_bucket_mount_test.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb93367a0e6d517fdd899087e7e12273facea745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->