### PR TITLE
Don't allow retrieving Cls.methods using functions.fromName

### DIFF
--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	pickle "github.com/kisielk/og-rek"
@@ -73,6 +74,13 @@ type FunctionFromNameParams struct {
 func (s *functionServiceImpl) FromName(ctx context.Context, appName string, name string, params *FunctionFromNameParams) (*Function, error) {
 	if params == nil {
 		params = &FunctionFromNameParams{}
+	}
+
+	if strings.Contains(name, ".") {
+		parts := strings.SplitN(name, ".", 2)
+		clsName := parts[0]
+		methodName := parts[1]
+		return nil, fmt.Errorf("cannot retrieve Cls methods using Functions.FromName(). Use:\n  cls, _ := client.Cls.FromName(ctx, \"%s\", \"%s\", nil)\n  instance, _ := cls.Instance(ctx, nil)\n  m, _ := instance.Method(\"%s\")", appName, clsName, methodName)
 	}
 
 	resp, err := s.client.cpClient.FunctionGet(ctx, pb.FunctionGetRequest_builder{

--- a/modal-go/test/function_test.go
+++ b/modal-go/test/function_test.go
@@ -201,3 +201,13 @@ func TestFunctionGetWebURL(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(wef.GetWebURL()).To(gomega.Equal("https://endpoint.internal"))
 }
+
+func TestFunctionFromNameWithDotNotation(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	_, err := tc.Functions.FromName(ctx, "libmodal-test-support", "MyClass.myMethod", nil)
+	g.Expect(err).Should(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.Equal("cannot retrieve Cls methods using Functions.FromName(). Use:\n  cls, _ := client.Cls.FromName(ctx, \"libmodal-test-support\", \"MyClass\", nil)\n  instance, _ := cls.Instance(ctx, nil)\n  m, _ := instance.Method(\"myMethod\")"))
+}

--- a/modal-js/src/function.ts
+++ b/modal-js/src/function.ts
@@ -47,6 +47,12 @@ export class FunctionService {
     name: string,
     params: FunctionFromNameParams = {},
   ): Promise<Function_> {
+    if (name.includes(".")) {
+      const [clsName, methodName] = name.split(".", 2);
+      throw new Error(
+        `Cannot retrieve Cls methods using 'functions.fromName()'. Use:\n  const cls = await client.cls.fromName("${appName}", "${clsName}");\n  const instance = await cls.instance();\n  const m = instance.method("${methodName}");`,
+      );
+    }
     try {
       const resp = await this.#client.cpClient.functionGet({
         appName,

--- a/modal-js/test/function.test.ts
+++ b/modal-js/test/function.test.ts
@@ -129,3 +129,13 @@ test("FunctionGetWebUrlOnNonWebFunction", async () => {
   );
   expect(await function_.getWebUrl()).toBeUndefined();
 });
+
+test("FunctionFromNameWithDotNotation", async () => {
+  const promise = tc.functions.fromName(
+    "libmodal-test-support",
+    "MyClass.myMethod",
+  );
+  await expect(promise).rejects.toThrowError(
+    `Cannot retrieve Cls methods using 'functions.fromName()'. Use:\n  const cls = await client.cls.fromName("libmodal-test-support", "MyClass");\n  const instance = await cls.instance();\n  const m = instance.method("myMethod");`,
+  );
+});


### PR DESCRIPTION
Mimics Python client behavior, but throws an error instead of just warning.