### PR TITLE
Fix JS pickle implementation and BININT2 unsignedness

### DIFF
--- a/modal-js/src/pickle.test.ts
+++ b/modal-js/src/pickle.test.ts
@@ -48,7 +48,33 @@ const testCases = [
   { name: "BININT1_0", b64: "gARLAC4=", expected: 0 },
   { name: "BININT1_255", b64: "gARL/y4=", expected: 255 },
   { name: "BININT2_-32768", b64: "gASVBgAAAAAAAABKAID//y4=", expected: -32768 },
+  { name: "BININT2_-32767", b64: "gASVBgAAAAAAAABKAYD//y4=", expected: -32767 },
   { name: "BININT2_32767", b64: "gASVBAAAAAAAAABN/38u", expected: 32767 },
+  {
+    name: "BININT2_32768 (unsigned boundary)",
+    b64: "gASVBAAAAAAAAABNAIAu",
+    expected: 32768,
+  },
+  {
+    name: "BININT2_36636",
+    b64: "gASVBAAAAAAAAABNHI8u",
+    expected: 36636,
+  },
+  {
+    name: "BININT4_-36636",
+    b64: "gASVBgAAAAAAAABK5HD//y4=",
+    expected: -36636,
+  },
+  {
+    name: "BININT2_65535 (max unsigned 16-bit)",
+    b64: "gASVBAAAAAAAAABN//8u",
+    expected: 65535,
+  },
+  {
+    name: "BININT4_-65535",
+    b64: "gASVBgAAAAAAAABKAQD//y4=",
+    expected: -65535,
+  },
   {
     name: "BININT4_-2147483648",
     b64: "gASVBgAAAAAAAABKAAAAgC4=",

--- a/modal-js/src/pickle.ts
+++ b/modal-js/src/pickle.ts
@@ -161,7 +161,7 @@ function encodeValue(val: any, w: Writer, proto: Protocol) {
       if (val >= 0 && val <= 0xff) {
         w.byte(Op.BININT1);
         w.byte(val);
-      } else if (val >= -0x8000 && val <= 0x7fff) {
+      } else if (val >= 0 && val <= 0xffff) {
         w.byte(Op.BININT2);
         w.byte(val & 0xff);
         w.byte((val >> 8) & 0xff);
@@ -319,7 +319,7 @@ export function loads(buf: Uint8Array): any {
         const lo = r.byte(),
           hi = r.byte();
         const n = (hi << 8) | lo;
-        push(n & 0x8000 ? n - 0x10000 : n);
+        push(n);
         break;
       }
       case Op.BININT4: {


### PR DESCRIPTION
From a user reported bug. Python's BININT2 is unsigned 16-bit (0-65535), but our old implementation treats it as signed (-32768 to 32767), meaning integers 32768-65535 were decoded as negative numbers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects `BININT2` to use unsigned 16-bit encoding/decoding and adds boundary tests for 16-bit/32-bit integers.
> 
> - **Pickle codec (`modal-js/src/pickle.ts`)**:
>   - **Encoding**: Use `BININT2` for unsigned 16-bit (`0..0xffff`) instead of signed range.
>   - **Decoding**: Parse `BININT2` as unsigned (`uint16`) without sign extension; keep `BININT1`/`BININT4` behavior unchanged.
> - **Tests (`modal-js/src/pickle.test.ts`)**:
>   - Add integer boundary cases covering `BININT2` unsigned limits (e.g., `32768`, `65535`) and corresponding negative values via `BININT4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1ef4a4997ec7c860567424831a159b974470f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->