### PR TITLE
Playing around with mise for env management + task management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 __pycache__/
 venv/
 .idea/
+.task_markers

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,42 @@
+experimental_monorepo_root = true
+
+[tasks.deploy-test-support]
+description = "Deploy test support apps"
+depends = [":py-bootstrap"]
+run = [
+    "modal-client/.venv/bin/modal deploy test-support/libmodal_test_support.py",
+    #"uvx 'modal<1.2' deploy test-support/test_support_1_1.py"
+    "mkdir -p .task_markers && touch .task_markers/last-test-support-deploy"
+]
+sources = ["test-support/**", "modal-client/**"]
+outputs = [".task_markers/last-test-support-deploy"]
+
+# The following would preferably live in modal-client itself
+# but that's blocked by mise naming of monorepo tasks vs non-monorepo tasks
+# https://github.com/jdx/mise/discussions/6564#discussioncomment-14646640
+[tools]
+python = "3.11"
+uv = "latest"
+
+[env]
+_.python.venv = {path = ".venv", create=true}
+
+[tasks.py-install]
+run = [
+    "uv pip install -r modal-client/requirements.dev.txt -e ./modal-client",
+    "mkdir -p .task_markers && touch .task_markers/py-install"
+]
+outputs = [".task_markers/py-install"]
+# technically sources here should include all top level package names
+# since they get symlinked in by the -e install, but that's hard to list
+sources = ["modal-client/requirements.dev.txt", "modal-client/pyproject.toml"]
+
+[tasks.py-protoc]
+run = "cd modal-client && inv protoc"
+sources = ["modal-client/modal_proto/*.proto"]
+outputs = ["modal-client/modal_proto/*.py"]
+depends = [":py-install"]
+
+[tasks.py-bootstrap]
+description = "Build and install the modal in ./modal-client"
+depends = [":py-install", ":py-protoc"]

--- a/modal-go/mise.toml
+++ b/modal-go/mise.toml
@@ -1,0 +1,7 @@
+[tools]
+go = "1.23"
+
+[tasks.test]
+description = "Test go"
+run = "go test -v -run ./test"
+depends = ["//:deploy-test-support"]

--- a/modal-js/mise.toml
+++ b/modal-js/mise.toml
@@ -1,0 +1,25 @@
+[tools]
+node = "22"
+
+[tasks.protoc]
+run = "./scripts/gen-proto.sh"
+sources = ["../modal-client/modal_proto/*.proto"]
+outputs = "proto/**/*.ts"
+depends = [":bootstrap"]
+
+[tasks.bootstrap]
+description = "Bootstrap or update js dev"
+run = "npm i"
+outputs = ["package-lock.json"]
+sources = ["package.json"]
+
+[tasks.build]
+run = "npm run build"
+depends = [":bootstrap", ":protoc"]
+sources = ["src/**/*.ts"]
+outputs = ["dist/index.js"]
+
+[tasks.test]
+description = "Test js"
+run = "npm test"
+depends = [":build", "//:deploy-test-support"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce mise-based monorepo task management with Python bootstrap/protoc, JS build/protoc, Go/JS tests, a test-support deploy task, and ignore task markers.
> 
> - **Build/Tasks (mise monorepo)**:
>   - **Root `mise.toml`**: Define monorepo tasks and tools (python 3.11, uv). Add tasks: `:py-install`, `:py-protoc`, `:py-bootstrap`, and `:deploy-test-support` (deploys Modal test support, writes `.task_markers/last-test-support-deploy`).
>   - **`modal-js/mise.toml`**: Add Node 22 and tasks `:bootstrap` (npm i), `:protoc` (generate TS from `../modal-client/modal_proto/*.proto`), `:build`, and `:test` (depends on `//:deploy-test-support`).
>   - **`modal-go/mise.toml`**: Add Go 1.23 and `:test` task (depends on `//:deploy-test-support`).
> - **Gitignore**:
>   - Ignore `.task_markers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 351dbb76a6c83905447985433ad6535417ee12b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->