### PR TITLE
Make npm test not run in watch mode by default

### DIFF
--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -32,7 +32,8 @@
     "format:check": "prettier --check .",
     "lint": "eslint",
     "prepare": "scripts/gen-proto.sh",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "version": "npm run check && git add -A && git commit -m \"modal-js/v$npm_package_version\"",
     "prepublishOnly": "npm run build && git push",
     "postpublish": "git tag modal-js/v$npm_package_version && git push --tags"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches default test to non-watch (`vitest run`) and adds `test:watch` for watch mode.
> 
> - **modal-js/package.json**
>   - **Scripts**:
>     - Change `test` to `vitest run` (non-watch mode by default).
>     - Add `test:watch` script running `vitest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0a71714514e0446d7fe75e20ca602ce8ba1a3fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->