### PR TITLE
Use trusted provider to publish to npm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
 
-
 jobs:
   publish:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
With trusted provider, we no longer need to use a NPM token to publish to npm. With the recent change to NPM security, newly created tokens would have to be rotated every 90 days.

I already enabled trusted provider on the NPM side to allow the `publish.yaml` workflow to push a release and configured a `publish` environment on Github.

Details here: https://docs.npmjs.com/trusted-publishers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `publish.yaml` to use npm Trusted Publisher via OIDC (add `environment: publish` and `permissions.id-token: write`) and remove `NODE_AUTH_TOKEN`.
> 
> - **CI/CD**:
>   - Update `/.github/workflows/publish.yaml` to use npm Trusted Publisher via OIDC:
>     - Add `environment: publish`.
>     - Grant `permissions: { id-token: write, contents: write }`.
>     - Remove `NODE_AUTH_TOKEN` from publish step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e036f876990e8f8d3f1abf7ad44957070e5fed2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->