### PR TITLE
Enable making dev pre-releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
-    if: startsWith(github.event.head_commit.message, '[RELEASE] Prepare release for')
+    if: startsWith(github.event.head_commit.message, '[RELEASE] Prepare release for') || startsWith(github.event.head_commit.message, '[DEV-RELEASE] Prepare dev release for')
     environment: publish
     permissions:
       id-token: write  # Required for OIDC for trusted provider: https://docs.npmjs.com/trusted-publishers#github-actions-configuration
@@ -41,4 +41,8 @@ jobs:
 
     - name: Publish and push tags
       run: |
-        python ci/release.py publish
+        if [[ "${{ github.event.head_commit.message }}" == "[DEV-RELEASE]"* ]]; then
+          python ci/release.py publish --dev
+        else
+          python ci/release.py publish
+        fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,14 @@ on:
         - patch
         - minor
         - major
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+        - stable
+        - dev
+        default: stable
 
 jobs:
   open-pr-for-release:
@@ -52,7 +60,7 @@ jobs:
     - name: Switch to ci-release and make release commits
       run: |
         git switch -c ci-release
-        python ci/release.py version ${{ inputs.update }}
+        python ci/release.py version ${{ inputs.update }} ${{ inputs.release_type == 'dev' && '--dev' || '' }}
         git push origin ci-release --force
 
     - name: Create Pull Request

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -34,9 +34,8 @@
     "prepare": "scripts/gen-proto.sh",
     "test": "vitest run",
     "test:watch": "vitest",
-    "version": "npm run check && git add -A && git commit -m \"modal-js/v$npm_package_version\"",
-    "prepublishOnly": "npm run build && git push",
-    "postpublish": "git tag modal-js/v$npm_package_version && git push --tags"
+    "version": "npm run check",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "cbor-x": "^1.6.0",


### PR DESCRIPTION
Main changes:
- enable making dev releases, like `v0.3.26-dev.0`
- will now enforce that the JS and Go SDKs have the same version (will manually bump to 0.5.0, and they will stay synced from there)
- add a `--dry-run` mode
- remove all git operations from `modal-js/package.json`, and move to `ci/release.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable dev pre-releases with synced JS/Go versions, add dry-run mode, and move git ops from npm scripts into the release CLI and workflows.
> 
> - **CI/CD**:
>   - **Publish workflow** (`.github/workflows/publish.yaml`):
>     - Trigger on `[DEV-RELEASE]` commits and conditionally run `python ci/release.py publish --dev`.
>   - **Release workflow** (`.github/workflows/release.yaml`):
>     - Add `release_type` input (`stable`|`dev`) and pass `--dev` to `version` when selected.
> - **Release CLI** (`ci/release.py`):
>   - Add `--dev` and `--dry-run` to `version` and `publish`.
>   - Dev versioning: use npm prerelease (`pre{update}`/`prerelease` with `--preid=dev`), commit with `[DEV-RELEASE]`.
>   - Stable versioning: bump JS version without git tag, update `CHANGELOG.md`, commit with `[RELEASE]`.
>   - Publish: push, `npm publish` (or `--tag next` for dev), create and push tags `modal-js/v<version>` and `modal-go/v<version>`, and ping Go proxy.
>   - Derive both JS and Go tags from `modal-js` `package.json` to keep versions in sync.
> - **JS package** (`modal-js/package.json`):
>   - Remove git side-effects from `version`/`prepublishOnly`/`postpublish`; `version` now only runs `check` and `prepublishOnly` only builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ddbdd2bd7d70ec8c2673ac8ca5cee831ef0e8bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->