### PR TITLE
Move GH workflow permissions to top level

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write  # Required for OIDC for trusted provider: https://docs.npmjs.com/trusted-publishers#github-actions-configuration
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-24.04
     if: startsWith(github.event.head_commit.message, '[RELEASE] Prepare release for') || startsWith(github.event.head_commit.message, '[DEV-RELEASE] Prepare dev release for')
     environment: publish
-    permissions:
-      id-token: write  # Required for OIDC for trusted provider: https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-      contents: write
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
According to  https://docs.npmjs.com/trusted-publishers#github-actions-configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `permissions` (`id-token`, `contents`) from the `publish` job to the workflow-level in `.github/workflows/publish.yaml`.
> 
> - **CI/CD**:
>   - **GitHub Actions** (`.github/workflows/publish.yaml`):
>     - Move `permissions` (`id-token`, `contents`) to workflow top level; remove job-level `permissions` from `publish` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f8e5c3d1409366700dbfdc297c715debff81c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->