### PR TITLE
Push git tags before npm publish

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -152,12 +152,12 @@ def publish(args):
 
     if args.dry_run:
         print("\nDRY RUN: Would execute the following operations:")
-        print("  - git push (push version commit)")
+        print("- git push (push version commit)")
+        print(f"- Create and push git tags: {js_tag}, {go_tag}")
         if args.dev:
-            print("  - npm publish --tag next (in modal-js/)")
+            print("- npm publish --tag next (in modal-js/)")
         else:
-            print("  - npm publish (in modal-js/)")
-        print(f"  - Create and push git tags: {js_tag}, {go_tag}")
+            print("- npm publish (in modal-js/)")
         return
 
     run_cli(["git", "push"])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Create and push git tags before running npm publish in the release script, with updated dry-run output.
> 
> - **ci/release.py**:
>   - Reorders `publish` flow to create and push `git` tags (`modal-js/v{version}`, `modal-go/v{version}`) before running `npm publish`.
>   - Updates dry-run output formatting and messaging to reflect the new order and use `-`-prefixed lines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b3c418a4ef664f1d4ae955d7a8d2235c1436fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->