### PR TITLE
Explicitly upgrade npm to a version that supports trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,9 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         cache-dependency-path: modal-js/package-lock.json
 
+    - name: Ensure npm 11.5.1 or later for trusted publishing
+      run: npm install -g npm@>=11.5.1
+
     - name: Install npm packages
       run: npm install
       working-directory: ./modal-js


### PR DESCRIPTION
As suggested here: https://github.com/orgs/community/discussions/174044#discussioncomment-14702054

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a step in `.github/workflows/publish.yaml` to upgrade npm to >=11.5.1 before publishing.
> 
> - **CI/CD**:
>   - Update `/.github/workflows/publish.yaml` to install `npm@>=11.5.1` prior to package install/publish to support trusted publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0055ba0ac11d9d2924c70ffefb1c3cf68a9cedb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->