### PR TITLE
Quote the npm version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,7 @@ jobs:
 
     - name: Ensure npm 11.5.1 or later for trusted publishing
       run: npm install -g 'npm@>=11.5.1'
+      working-directory: ./modal-js
 
     - name: Install npm packages
       run: npm install


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Quotes the npm version spec in the publish GitHub Actions workflow to ensure correct shell parsing.
> 
> - **CI (GitHub Actions)**:
>   - Update `run` command in `.github/workflows/publish.yaml` to quote `npm@>=11.5.1` during global install for trusted publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86be8e836e8ae46df5a08fded1d5e8bc51598c62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->