### PR TITLE
Don't set Sandbox resource defaults in SDK

### DIFF
--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -295,11 +295,10 @@ export async function buildSandboxCreateRequestProto(
       workdir: params.workdir ?? undefined,
       networkAccess,
       resources: {
-        // https://modal.com/docs/guide/resources
-        milliCpu: milliCpu ?? Math.trunc(1000 * 0.125),
-        milliCpuMax: milliCpuMax ?? 0,
-        memoryMb: memoryMb ?? 128,
-        memoryMbMax: memoryMbMax ?? 0,
+        milliCpu,
+        milliCpuMax,
+        memoryMb,
+        memoryMbMax,
         gpuConfig,
       },
       volumeMounts,


### PR DESCRIPTION
Let the server set fallback defaults like for the other SDKs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop setting client-side CPU/memory defaults for Sandbox resources; pass through values so server applies fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16a32b281aeb3ad6bb639fa8da9f8e8110c3e32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->