### PR TITLE
Minor pre-beta copy updates

### DIFF
--- a/modal-go/doc.go
+++ b/modal-go/doc.go
@@ -1,7 +1,7 @@
-// Package modal is a lightweight, idiomatic Go client for Modal.com.
+// Package modal is a lightweight, idiomatic Go SDK for Modal.com.
 //
-// The library mirrors the core feature-set of Modal’s Python client while
-// feeling natural in Go:
+// It mirrors the core feature-set of Modal’s Python SDK while feeling
+// natural in Go:
 //
 //   - Spin up Sandboxes — fast, secure, ephemeral VMs for running code.
 //   - Invoke Modal Functions and manage their inputs / outputs.
@@ -14,7 +14,7 @@
 //
 // # Authentication
 //
-// At runtime the client resolves credentials in this order:
+// At runtime the SDK resolves credentials in this order:
 //
 //  1. Environment variables
 //     MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, MODAL_ENVIRONMENT (optional)
@@ -23,11 +23,6 @@
 //
 // See `config.go` for the resolution logic.
 //
-// # Stability
-//
-// `libmodal` is **alpha** software; the API may change without notice until
-// a v1.0.0 release. Please pin versions and file issues generously.
-//
 // For additional examples and language-parity tests, see
-// https://github.com/modal-labs/libmodal.
+// https://github.com/modal-labs/libmodal/tree/main/modal-go.
 package modal

--- a/modal-js/package.json
+++ b/modal-js/package.json
@@ -1,9 +1,9 @@
 {
   "name": "modal",
   "version": "0.5.0-dev.7",
-  "description": "Modal client library for JavaScript",
+  "description": "Modal SDK for JavaScript/TypeScript",
   "license": "Apache-2.0",
-  "homepage": "https://modal.com/docs",
+  "homepage": "https://modal.com/docs/guide/sdk-javascript-go",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/modal-labs/libmodal.git"

--- a/test-support/README.md
+++ b/test-support/README.md
@@ -2,7 +2,7 @@
 
 Sign in to Modal, which you'll use for running the test programs.
 
-Then deploy the apps and secrets in this folder using the Python client. This
+Then deploy the apps and secrets in this folder using the Python SDK. This
 requires being signed in to AWS (Modal Labs account):
 
 ```bash


### PR DESCRIPTION
- Use "SDK" rather than "client".
- Remove language about alpha status - semver indicates maturity going forward.
- Update docs link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace “client” with “SDK,” update docs/homepage links, and remove the Go alpha stability note.
> 
> - **Go (`modal-go/doc.go`)**:
>   - Switch terminology from “client” to “SDK” and align phrasing with Python SDK.
>   - Remove alpha stability section.
>   - Update examples/docs link to `libmodal/tree/main/modal-go`.
> - **JavaScript (`modal-js/package.json`)**:
>   - Update description to “SDK for JavaScript/TypeScript.”
>   - Change homepage to `https://modal.com/docs/guide/sdk-javascript-go`.
> - **Test Support (`test-support/README.md`)**:
>   - Replace “Python client” with “Python SDK.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e80803b6afe884c95b44bd672b2d5e764bbe1c12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->