### PR TITLE
Fix docs links in READMEs

### DIFF
--- a/modal-go/README.md
+++ b/modal-go/README.md
@@ -40,7 +40,7 @@ Go 1.23 or later.
 
 ## Documentation
 
-See the main [Modal documentation](https://modal.com/docs/guide) and [user guides](https://modal.com/docs/guide) for high-level overviews. For details, see the [API reference documentation for for Go](https://pkg.go.dev/github.com/modal-labs/libmodal/modal-go#section-documentation).
+See the main [Modal documentation](https://modal.com/docs) and [user guides](https://modal.com/docs/guide) for high-level overviews. For details, see the [API reference documentation for for Go](https://pkg.go.dev/github.com/modal-labs/libmodal/modal-go#section-documentation).
 
 We also provide a number of examples:
 - [Call a deployed Function](./examples/function-call/main.go)

--- a/modal-js/README.md
+++ b/modal-js/README.md
@@ -27,7 +27,7 @@ Node 22 or later. We bundle both ES Modules and CommonJS formats, so you can loa
 
 ## Documentation
 
-See the main [Modal documentation](https://modal.com/docs/guide) and [user guides](https://modal.com/docs/guide) for high-level overviews. For details, see the [API reference documentation for for JS](https://modal-labs.github.io/libmodal/).
+See the main [Modal documentation](https://modal.com/docs) and [user guides](https://modal.com/docs/guide) for high-level overviews. For details, see the [API reference documentation for for JS](https://modal-labs.github.io/libmodal/).
 
 We also provide a number of examples:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix main docs links in Go and JS READMEs to point to `/docs` instead of `/guide`.
> 
> - **Docs**:
>   - Update main docs link from `https://modal.com/docs/guide` to `https://modal.com/docs` in `modal-go/README.md` and `modal-js/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8ea6c80180365da0cdf245f300cba5efa38e839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->