### PR TITLE
Simplify the `Image.delete()` implementations

### DIFF
--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -318,11 +318,9 @@ type ImageDeleteParams struct {
 
 // Delete deletes an Image by ID. Warning: This removes an *entire Image*, and cannot be undone.
 func (s *imageServiceImpl) Delete(ctx context.Context, imageID string, params *ImageDeleteParams) error {
-	image, err := s.FromID(ctx, imageID)
-	if err != nil {
-		return err
+	_, err := s.client.cpClient.ImageDelete(ctx, pb.ImageDeleteRequest_builder{ImageId: imageID}.Build())
+	if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
+		return NotFoundError{fmt.Sprintf("Image '%s' not found", imageID)}
 	}
-
-	_, err = s.client.cpClient.ImageDelete(ctx, pb.ImageDeleteRequest_builder{ImageId: image.ImageID}.Build())
 	return err
 }

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -120,8 +120,19 @@ export class ImageService {
    * Delete an {@link Image} by ID. Warning: This removes an *entire Image*, and cannot be undone.
    */
   async delete(imageId: string, _: ImageDeleteParams = {}): Promise<void> {
-    const image = await this.fromId(imageId);
-    await this.#client.cpClient.imageDelete({ imageId: image.imageId });
+    try {
+      await this.#client.cpClient.imageDelete({ imageId });
+    } catch (err) {
+      if (err instanceof ClientError && err.code === Status.NOT_FOUND)
+        throw new NotFoundError(err.details);
+      if (
+        err instanceof ClientError &&
+        err.code === Status.FAILED_PRECONDITION &&
+        err.details.includes("Could not find image with ID")
+      )
+        throw new NotFoundError(err.details);
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
They made an unneccessary GRPC call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies image deletion by removing the pre-fetch call and mapping backend NotFound responses consistently in Go and TypeScript.
> 
> - **Image deletion**:
>   - **Go (`modal-go/image.go`)**: Remove `FromID` pre-check; call `cpClient.ImageDelete` directly and translate `NotFound` to `NotFoundError`.
>   - **TypeScript (`modal-js/src/image.ts`)**: Remove `fromId` call; call `cpClient.imageDelete` directly and map `NOT_FOUND` and specific `FAILED_PRECONDITION` messages to `NotFoundError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2273ac94e7180180ab9cb055060957767782df3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->