### PR TITLE
Add support for MODAL_CONFIG_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Both client libraries are pre-1.0, and they have separate versioning.
 ## Unreleased
 
 - All Go SDK functions that take a Context will respect the timeout of the context.
+- Allow customizing the config file path via `MODAL_CONFIG_PATH` environment variable (defaults to `~/.modal.toml`).
 
 ## modal-js/v0.5.0, modal-go/v0.5.0
 

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -35,14 +35,26 @@ type rawProfile struct {
 
 type config map[string]rawProfile
 
-// readConfigFile loads ~/.modal.toml, returning an empty config if the file
-// does not exist.
-func readConfigFile() (config, error) {
+func configFilePath() (string, error) {
+	if configPath := os.Getenv("MODAL_CONFIG_PATH"); configPath != "" {
+		return configPath, nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("cannot locate homedir: %w", err)
+		return "", fmt.Errorf("cannot locate homedir: %w", err)
 	}
-	path := filepath.Join(home, ".modal.toml")
+	return filepath.Join(home, ".modal.toml"), nil
+}
+
+// readConfigFile loads the Modal config file, returning an empty config if the file
+// does not exist.
+func readConfigFile() (config, error) {
+	path, err := configFilePath()
+	if err != nil {
+		return nil, err
+	}
+
 	content, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return config{}, nil // silent absence is fine

--- a/modal-go/config_test.go
+++ b/modal-go/config_test.go
@@ -1,0 +1,51 @@
+package modal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestGetConfigPath_WithEnvVar(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	originalPath := os.Getenv("MODAL_CONFIG_PATH")
+	defer func() {
+		if originalPath != "" {
+			os.Setenv("MODAL_CONFIG_PATH", originalPath)
+		} else {
+			os.Unsetenv("MODAL_CONFIG_PATH")
+		}
+	}()
+
+	customPath := "/custom/path/to/config.toml"
+	os.Setenv("MODAL_CONFIG_PATH", customPath)
+
+	path, err := configFilePath()
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(path).Should(gomega.Equal(customPath))
+}
+
+func TestGetConfigPath_WithoutEnvVar(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	originalPath := os.Getenv("MODAL_CONFIG_PATH")
+	defer func() {
+		if originalPath != "" {
+			os.Setenv("MODAL_CONFIG_PATH", originalPath)
+		} else {
+			os.Unsetenv("MODAL_CONFIG_PATH")
+		}
+	}()
+
+	os.Unsetenv("MODAL_CONFIG_PATH")
+
+	path, err := configFilePath()
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	home, _ := os.UserHomeDir()
+	expectedPath := filepath.Join(home, ".modal.toml")
+	g.Expect(path).Should(gomega.Equal(expectedPath))
+}

--- a/modal-go/doc.go
+++ b/modal-go/doc.go
@@ -12,7 +12,11 @@
 // handled in Python; this package is for calling and orchestrating them
 // from other projects.
 //
-// # Authentication
+// # Configuration
+//
+// The config file path can be customized via `MODAL_CONFIG_PATH` (defaults to `~/.modal.toml`).
+//
+// ## Authentication
 //
 // At runtime the SDK resolves credentials in this order:
 //
@@ -21,9 +25,7 @@
 //  2. A profile explicitly requested via `MODAL_PROFILE`
 //  3. A profile marked `active = true` in `~/.modal.toml`
 //
-// See `config.go` for the resolution logic.
-//
-// # Logging
+// ## Logging
 //
 // The SDK logging level can be controlled in multiple ways (in order of precedence):
 //

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -27,9 +27,18 @@ export interface Profile {
   logLevel?: string;
 }
 
+export function configFilePath(): string {
+  const configPath = process.env["MODAL_CONFIG_PATH"];
+  if (configPath && configPath !== "") {
+    return configPath;
+  }
+  return path.join(homedir(), ".modal.toml");
+}
+
 function readConfigFile(): Config {
   try {
-    const configContent = readFileSync(path.join(homedir(), ".modal.toml"), {
+    const configPath = configFilePath();
+    const configContent = readFileSync(configPath, {
       encoding: "utf-8",
     });
     return parseToml(configContent) as Config;

--- a/modal-js/test/config.test.ts
+++ b/modal-js/test/config.test.ts
@@ -1,0 +1,24 @@
+import { expect, test, vi } from "vitest";
+import { homedir } from "node:os";
+import path from "node:path";
+import { configFilePath } from "../src/config";
+
+test("GetConfigPath_WithEnvVar", () => {
+  const customPath = "/custom/path/to/config.toml";
+  vi.stubEnv("MODAL_CONFIG_PATH", customPath);
+
+  const result = configFilePath();
+  expect(result).toBe(customPath);
+
+  vi.unstubAllEnvs();
+});
+
+test("GetConfigPath_WithoutEnvVar", () => {
+  vi.stubEnv("MODAL_CONFIG_PATH", undefined);
+
+  const result = configFilePath();
+  const expectedPath = path.join(homedir(), ".modal.toml");
+  expect(result).toBe(expectedPath);
+
+  vi.unstubAllEnvs();
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add cross-SDK support for `MODAL_CONFIG_PATH` to customize the config file path (default `~/.modal.toml`), with tests and docs updates.
> 
> - **Config resolution (JS & Go)**:
>   - Support `MODAL_CONFIG_PATH` to override config location (default `~/.modal.toml`).
>   - Update `CHANGELOG.md` accordingly.
> - **Go (`modal-go`)**:
>   - Add `configFilePath()` and use it in `readConfigFile()`.
>   - Add tests `TestGetConfigPath_WithEnvVar` and `TestGetConfigPath_WithoutEnvVar`.
>   - Update `doc.go` with a Configuration section mentioning `MODAL_CONFIG_PATH`.
> - **JS (`modal-js`)**:
>   - Add `configFilePath()` and use it in `readConfigFile()`.
>   - Add tests `GetConfigPath_WithEnvVar` and `GetConfigPath_WithoutEnvVar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86fc036d12f3936dae5a314352885c6428dbd6eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->