### PR TITLE
Fix goroutine leak in output streaming functions

### DIFF
--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -765,15 +765,15 @@ func newContainerProcess(cpClient pb.ModalClientClient, execID string, params Sa
 	cp := &ContainerProcess{execID: execID, cpClient: cpClient}
 	cp.Stdin = inputStreamCp(cpClient, execID)
 
-	cp.Stdout = outputStreamCp(cpClient, execID, pb.FileDescriptor_FILE_DESCRIPTOR_STDOUT)
 	if stdoutBehavior == Ignore {
-		cp.Stdout.Close()
 		cp.Stdout = io.NopCloser(bytes.NewReader(nil))
+	} else {
+		cp.Stdout = outputStreamCp(cpClient, execID, pb.FileDescriptor_FILE_DESCRIPTOR_STDOUT)
 	}
-	cp.Stderr = outputStreamCp(cpClient, execID, pb.FileDescriptor_FILE_DESCRIPTOR_STDERR)
 	if stderrBehavior == Ignore {
-		cp.Stderr.Close()
 		cp.Stderr = io.NopCloser(bytes.NewReader(nil))
+	} else {
+		cp.Stderr = outputStreamCp(cpClient, execID, pb.FileDescriptor_FILE_DESCRIPTOR_STDERR)
 	}
 
 	return cp

--- a/modal-go/test/sandbox_test.go
+++ b/modal-go/test/sandbox_test.go
@@ -675,7 +675,6 @@ func TestNoGoroutineLeaksWithIgnoredOutput(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			ctx := context.Background()
@@ -711,8 +710,10 @@ func TestNoGoroutineLeaksWithIgnoredOutput(t *testing.T) {
 			runtime.GC()
 			time.Sleep(500 * time.Millisecond)
 
-			finalGoroutines := runtime.NumGoroutine()
-			g.Expect(finalGoroutines).To(gomega.Equal(initialGoroutines))
+			g.Eventually(func() int {
+				runtime.GC()
+				return runtime.NumGoroutine()
+			}, 5*time.Second, 100*time.Millisecond).Should(gomega.Equal(initialGoroutines))
 		})
 	}
 }


### PR DESCRIPTION
Background goroutines in outputStreamSb and outputStreamCp used context.Background() which prevented cancellation when streams were closed early (e.g., via modal.Ignore).

Now use cancellable contexts that terminate immediately when the reader is closed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make output stream goroutines cancel on Close and skip creating stdout/stderr when ignored; add leak-check test.
> 
> - **Sandbox I/O**:
>   - `outputStreamSb`/`outputStreamCp`: use cancellable contexts, check `ctx.Err()`, and wrap readers with `cancelOnCloseReader` to stop background goroutines on `Close`.
>   - `newContainerProcess`: only create `Stdout`/`Stderr` streams when not `modal.Ignore`; otherwise use `io.NopCloser(bytes.NewReader(nil))`.
> - **Tests**:
>   - Add `TestNoGoroutineLeaksWithIgnoredOutput` to verify no goroutine leaks when outputs are ignored or explicitly closed (adds `runtime` import).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd34af94845d91e9477558144960165fa0423234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->