### PR TITLE
.github: Use OIDC when authenticating with AWS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  id-token: write # id-token is required to for OIDC
+
 on:
   push:
     branches:
@@ -15,6 +18,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: true
+
+      - uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
+        with:
+          role-to-assume: arn:aws:iam::459781239556:role/libmodal-ci-cd-role-62a288d
+          aws-region: us-east-1
 
       - name: Install uv
         uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5
@@ -45,9 +53,6 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           MODAL_ENVIRONMENT: libmodal
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
           MODAL_SYNC_ENTRYPOINT: 1
 
   js:


### PR DESCRIPTION
Makes use of OpenID Connect to authenticate with AWS and assume a role specific to this repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch CI AWS auth to OIDC by assuming an IAM role and removing static AWS keys from the workflow.
> 
> - **CI workflow (`.github/workflows/ci.yaml`)**:
>   - Enable OIDC by adding `permissions: id-token: write`.
>   - Configure AWS credentials via `aws-actions/configure-aws-credentials` to assume role `arn:aws:iam::459781239556:role/libmodal-ci-cd-role-62a288d` in `us-east-1`.
>   - Remove static AWS env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) from `test-support/setup.sh` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 157b296b1724160d473a2780744cc068976cc355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->