### PR TITLE
Implement http resource handling fix plan

### DIFF
--- a/modal-go/examples/sandbox-tunnels/main.go
+++ b/modal-go/examples/sandbox-tunnels/main.go
@@ -68,7 +68,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to make GET request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Printf("Failed to close response body: %v", cerr)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Fatalf("HTTP error! status: %d", resp.StatusCode)

--- a/modal-go/invocation_test.go
+++ b/modal-go/invocation_test.go
@@ -1,0 +1,77 @@
+package modal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+	"google.golang.org/grpc"
+)
+
+type fakeBlobGetter struct {
+	urls map[string]string
+}
+
+func (f *fakeBlobGetter) BlobGet(ctx context.Context, req *pb.BlobGetRequest, opts ...grpc.CallOption) (*pb.BlobGetResponse, error) {
+	url, ok := f.urls[req.GetBlobId()]
+	if !ok {
+		return nil, fmt.Errorf("unknown blob id: %s", req.GetBlobId())
+	}
+	return pb.BlobGetResponse_builder{
+		DownloadUrl: url,
+	}.Build(), nil
+}
+
+func TestBlobDownloadSuccess(t *testing.T) {
+	t.Parallel()
+
+	want := []byte("hello world")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(want); err != nil {
+			t.Fatalf("failed to write response body: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &fakeBlobGetter{
+		urls: map[string]string{"blob-id": server.URL},
+	}
+
+	got, err := blobDownload(context.Background(), client, "blob-id")
+	if err != nil {
+		t.Fatalf("blobDownload returned error: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("blobDownload = %q, want %q", got, want)
+	}
+}
+
+func TestBlobDownloadErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "permission denied", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &fakeBlobGetter{
+		urls: map[string]string{"blob-id": server.URL},
+	}
+
+	_, err := blobDownload(context.Background(), client, "blob-id")
+	if err == nil {
+		t.Fatal("blobDownload expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "status=403") {
+		t.Fatalf("error %q missing status detail", err)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("error %q missing body preview", err)
+	}
+}


### PR DESCRIPTION
Improve HTTP resource handling for blob downloads and the tunnels example.

This prevents connection leaks in the tunnels example and hardens blob downloads with better error handling and dedicated tests to avoid regressions.

---
<a href="https://cursor.com/background-agent?bcId=bc-167a14cb-45da-4c1a-bce1-a96449733825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-167a14cb-45da-4c1a-bce1-a96449733825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves HTTP handling by safely closing response bodies in the tunnels example and strengthening blob download error handling with dedicated tests.
> 
> - **Core (`modal-go/invocation.go`)**:
>   - Refactor `blobDownload` to use a `blobGetter` interface; add `grpc` import.
>   - Improve error handling for non-2xx downloads with status checks and limited body preview; include `blob_id` and URL in errors.
> - **Tests (`modal-go/invocation_test.go`)**:
>   - Add tests covering successful download and forbidden status with body preview.
> - **Example (`modal-go/examples/sandbox-tunnels/main.go`)**:
>   - Safely close `resp.Body` with logged error on close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28fe66218d11ffc3aaeb43cc3f74b2ff6b2bed0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->