### PR TITLE
Set `SchedulerPlacement` to `nil`/`undefined` if `region` is not specified

### DIFF
--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -153,7 +153,10 @@ func buildSandboxCreateRequestProto(appID, imageID string, params SandboxCreateP
 		}.Build()
 	}
 
-	schedulerPlacement := pb.SchedulerPlacement_builder{Regions: params.Regions}.Build()
+	var schedulerPlacement *pb.SchedulerPlacement
+	if len(params.Regions) > 0 {
+		schedulerPlacement = pb.SchedulerPlacement_builder{Regions: params.Regions}.Build()
+	}
 
 	var proxyID *string
 	if params.Proxy != nil {

--- a/modal-js/src/sandbox.ts
+++ b/modal-js/src/sandbox.ts
@@ -239,9 +239,12 @@ export async function buildSandboxCreateRequestProto(
     };
   }
 
-  const schedulerPlacement = SchedulerPlacement.create({
-    regions: params.regions ?? [],
-  });
+  const schedulerPlacement: SchedulerPlacement | undefined = params.regions
+    ?.length
+    ? SchedulerPlacement.create({
+        regions: params.regions,
+      })
+    : undefined;
 
   let ptyInfo: PTYInfo | undefined;
   if (params.pty) {


### PR DESCRIPTION
We should not be sending `SchedulerPlacement` if a `region` is not specified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only include `SchedulerPlacement` in sandbox create requests when `regions` is non-empty; otherwise send nil/undefined.
> 
> - **Sandbox create request**
>   - Go (`modal-go/sandbox.go`): Set `schedulerPlacement` to `nil` unless `params.Regions` has entries.
>   - JS (`modal-js/src/sandbox.ts`): Set `schedulerPlacement` to `undefined` unless `params.regions` has entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce8f2f988034621f7dac893300f8571341f50a31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->