### PR TITLE
Fix GitHub Actions set-output deprecation warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
+      - uses: aws-actions/configure-aws-credentials@be2e7ad815e27b890489a89ce2717b0f9e26b56e # v4
         with:
           role-to-assume: arn:aws:iam::459781239556:role/libmodal-ci-cd-role-62a288d
           aws-region: us-east-1


### PR DESCRIPTION
Update aws-actions/configure-aws-credentials from v1 to v4 to resolve this warning:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump `aws-actions/configure-aws-credentials` from v1 to v4 in `.github/workflows/ci.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f54ba045babc716a6880e8eb0e3d84b4ae2eff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->