### PR TITLE
feat(js): add experimental sandbox memory snapshot support

### DIFF
--- a/modal-js/src/cloud_bucket_mount.ts
+++ b/modal-js/src/cloud_bucket_mount.ts
@@ -156,6 +156,7 @@ export class CloudBucketMount {
       bucketEndpointUrl: this.bucketEndpointUrl,
       keyPrefix: this.keyPrefix,
       oidcAuthRoleArn: this.oidcAuthRoleArn,
+      forcePathStyle: false,
     };
   }
 }

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -62,6 +62,7 @@ export { Retries } from "./retries";
 export type {
   SandboxExecParams,
   SandboxFromNameParams,
+  SandboxFromSnapshotParams,
   SandboxCreateConnectCredentials,
   SandboxCreateConnectTokenParams,
   StdioBehavior,
@@ -70,7 +71,12 @@ export type {
   SandboxListParams,
   SandboxCreateParams,
 } from "./sandbox";
-export { ContainerProcess, Sandbox, SandboxService } from "./sandbox";
+export {
+  ContainerProcess,
+  Sandbox,
+  SandboxService,
+  SandboxSnapshot,
+} from "./sandbox";
 export type { ModalReadStream, ModalWriteStream } from "./streams";
 export {
   Secret,

--- a/modal-js/test/sandbox.test.ts
+++ b/modal-js/test/sandbox.test.ts
@@ -724,3 +724,29 @@ test("sandboxInvalidTimeouts", async () => {
     sandbox.exec(["echo", "test"], { timeoutMs: 1500 }),
   ).rejects.toThrow(/timeoutMs must be a multiple of 1000ms/);
 });
+
+test("buildSandboxCreateRequestProto with experimentalOptions", async () => {
+  const req = await buildSandboxCreateRequestProto("app-123", "img-456", {
+    experimentalOptions: { enable_docker: true },
+  });
+
+  const def = req.definition!;
+  expect(def.experimentalOptions).toEqual({ enable_docker: true });
+});
+
+test("buildSandboxCreateRequestProto with _experimentalEnableSnapshot", async () => {
+  const req = await buildSandboxCreateRequestProto("app-123", "img-456", {
+    _experimentalEnableSnapshot: true,
+  });
+
+  const def = req.definition!;
+  expect(def.enableSnapshot).toBe(true);
+});
+
+test("buildSandboxCreateRequestProto defaults experimental fields", async () => {
+  const req = await buildSandboxCreateRequestProto("app-123", "img-456");
+  const def = req.definition!;
+
+  expect(def.experimentalOptions).toEqual({});
+  expect(def.enableSnapshot).toBe(false);
+});


### PR DESCRIPTION
## Summary

- Add experimental memory snapshot support to the JavaScript/TypeScript SDK
- Add `SandboxSnapshot` class and `_experimentalSnapshot()` / `_experimentalFromSnapshot()` methods for creating and restoring sandbox memory snapshots
- Add `experimentalOptions` parameter to `SandboxCreateParams` for server-side feature flags
- Fix missing `forcePathStyle` field in `CloudBucketMount` proto conversion

## Changes

### New Features
- `sandbox._experimentalSnapshot()`: Takes a memory snapshot of a running sandbox
- `sandboxes._experimentalFromSnapshot(snapshot, params)`: Restores a sandbox from a snapshot
- `SandboxSnapshot` class: Represents a stored sandbox snapshot
- `_experimentalEnableSnapshot` option in `SandboxCreateParams`: Enables memory snapshots for a sandbox
- `experimentalOptions` in `SandboxCreateParams`: Pass experimental feature flags to the server

### Bug Fixes
- Added missing `forcePathStyle: false` to `CloudBucketMount.toProto()`

## Test Plan

- [x] Added unit tests for `buildSandboxCreateRequestProto` with new experimental options
- [x] Manual testing of snapshot/restore functionality with a live Modal environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds experimental sandbox memory snapshot create/restore APIs, exposes `SandboxSnapshot`, supports experimental options in create params, and fixes missing `forcePathStyle` in cloud bucket mount proto.
> 
> - **Sandbox (experimental snapshots)**:
>   - Add `Sandbox#_experimentalSnapshot()` to create memory snapshots and wait for completion.
>   - Add `SandboxService#_experimentalFromSnapshot()` to restore from `SandboxSnapshot` with optional name override handling.
>   - Introduce `SandboxSnapshot` class and `SandboxFromSnapshotParams` type.
>   - Extend `SandboxCreateParams` with `experimentalOptions` and `_experimentalEnableSnapshot`; include `experimentalOptions` and `enableSnapshot` in create request proto.
> - **Exports**:
>   - Export `SandboxSnapshot` and `SandboxFromSnapshotParams` from `index.ts`.
> - **Cloud bucket mounts**:
>   - Include `forcePathStyle: false` in `CloudBucketMount#toProto()`.
> - **Tests**:
>   - Add unit tests covering `experimentalOptions`, `_experimentalEnableSnapshot`, and their defaults in `buildSandboxCreateRequestProto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90f057690757130ee72536ce49e27f01ba4c41c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->