### PR TITLE
Fetch image builder version from Modal settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
-No unreleased changes.
+**Breaking changes:**
+- The JS and Go SDKs now read the [Image Builder Version](https://modal.com/docs/guide/images#image-builder-updates) from your Modal account settings, like the Python SDK (see Image Config in Settings in the web UI). Previously they used version `2024.10`. If your account version is newer, your Images will rebuild once (then be cached as usual), so beware that the first run after upgrading may take longer than usual.
 
 ## modal-js/v0.6.0, modal-go/v0.6.0
 

--- a/modal-go/app.go
+++ b/modal-go/app.go
@@ -71,7 +71,7 @@ func (s *appServiceImpl) FromName(ctx context.Context, name string, params *AppF
 
 	resp, err := s.client.cpClient.AppGetOrCreate(ctx, pb.AppGetOrCreateRequest_builder{
 		AppName:            name,
-		EnvironmentName:    environmentName(params.Environment, s.client.profile),
+		EnvironmentName:    firstNonEmpty(params.Environment, s.client.profile.Environment),
 		ObjectCreationType: creationType,
 	}.Build())
 

--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -74,6 +75,8 @@ type Client struct {
 	logger                       *slog.Logger
 	cpClient                     *clientWithConn            // control plane client
 	ipClients                    map[string]*clientWithConn // input plane clients
+	environmentsCache            sync.Map
+	environmentGroup             singleflight.Group
 	authTokenManager             *AuthTokenManager
 	additionalUnaryInterceptors  []grpc.UnaryClientInterceptor
 	additionalStreamInterceptors []grpc.StreamClientInterceptor

--- a/modal-go/cls.go
+++ b/modal-go/cls.go
@@ -100,7 +100,7 @@ func (s *clsServiceImpl) FromName(ctx context.Context, appName string, name stri
 	serviceFunction, err := s.client.cpClient.FunctionGet(ctx, pb.FunctionGetRequest_builder{
 		AppName:         appName,
 		ObjectTag:       serviceFunctionName,
-		EnvironmentName: environmentName(params.Environment, s.client.profile),
+		EnvironmentName: firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 
 	if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
@@ -291,7 +291,7 @@ func (c *Cls) bindParameters(ctx context.Context, parameters map[string]any, opt
 		FunctionId:       c.serviceFunctionID,
 		SerializedParams: serializedParams,
 		FunctionOptions:  functionOptions,
-		EnvironmentName:  environmentName("", c.client.profile),
+		EnvironmentName:  c.client.profile.Environment,
 	}.Build())
 	if err != nil {
 		return "", fmt.Errorf("failed to bind parameters: %w", err)

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -114,7 +114,3 @@ func firstNonEmpty(values ...string) string {
 	}
 	return ""
 }
-
-func environmentName(environment string, profile Profile) string {
-	return firstNonEmpty(environment, profile.Environment)
-}

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -118,7 +118,3 @@ func firstNonEmpty(values ...string) string {
 func environmentName(environment string, profile Profile) string {
 	return firstNonEmpty(environment, profile.Environment)
 }
-
-func imageBuilderVersion(version string, profile Profile) string {
-	return firstNonEmpty(version, profile.ImageBuilderVersion, "2024.10")
-}

--- a/modal-go/environment.go
+++ b/modal-go/environment.go
@@ -1,0 +1,84 @@
+package modal
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+)
+
+// Environment represents a Modal Environment with its server-provided settings.
+type Environment struct {
+	ID       string
+	Name     string
+	Settings EnvironmentSettings
+}
+
+// EnvironmentSettings contains environment-scoped configuration from the server.
+type EnvironmentSettings struct {
+	ImageBuilderVersion string
+	WebhookSuffix       string
+}
+
+// fetchEnvironment fetches an environment from the server, caching the result.
+// Pass an empty string for name to get the default environment.
+func (c *Client) fetchEnvironment(ctx context.Context, name string) (*Environment, error) {
+	if cached, ok := c.environmentsCache.Load(name); ok {
+		return cached.(*Environment), nil
+	}
+
+	result, err, _ := c.environmentGroup.Do(name, func() (interface{}, error) {
+		if cached, ok := c.environmentsCache.Load(name); ok {
+			return cached.(*Environment), nil
+		}
+
+		c.logger.DebugContext(ctx, "Fetching environment from server", "environment_name", name)
+
+		resp, err := c.cpClient.EnvironmentGetOrCreate(ctx, pb.EnvironmentGetOrCreateRequest_builder{
+			DeploymentName: name,
+		}.Build())
+		if err != nil {
+			return nil, err
+		}
+
+		metadata := resp.GetMetadata()
+		settings := metadata.GetSettings()
+
+		env := &Environment{
+			ID:   resp.GetEnvironmentId(),
+			Name: metadata.GetName(),
+			Settings: EnvironmentSettings{
+				ImageBuilderVersion: settings.GetImageBuilderVersion(),
+				WebhookSuffix:       settings.GetWebhookSuffix(),
+			},
+		}
+
+		c.environmentsCache.Store(name, env)
+		c.logger.DebugContext(ctx, "Cached environment",
+			"environment_name", name,
+			"environment_id", env.ID,
+			"image_builder_version", env.Settings.ImageBuilderVersion)
+
+		return env, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return result.(*Environment), nil
+}
+
+// imageBuilderVersion returns the image builder version to use for image builds.
+// Precedence: local config > server-provided value.
+func (c *Client) imageBuilderVersion(ctx context.Context, environmentName string) (string, error) {
+	if c.profile.ImageBuilderVersion != "" {
+		return c.profile.ImageBuilderVersion, nil
+	}
+
+	env, err := c.fetchEnvironment(ctx, environmentName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get environment for image builder version: %w", err)
+	}
+
+	return env.Settings.ImageBuilderVersion, nil
+}

--- a/modal-go/environment_test.go
+++ b/modal-go/environment_test.go
@@ -1,0 +1,125 @@
+package modal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	pb "github.com/modal-labs/libmodal/modal-go/proto/modal_proto"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+)
+
+type mockEnvironmentClient struct {
+	pb.ModalClientClient
+	callCount atomic.Int64
+	envs      sync.Map
+}
+
+func (m *mockEnvironmentClient) EnvironmentGetOrCreate(ctx context.Context, req *pb.EnvironmentGetOrCreateRequest, opts ...grpc.CallOption) (*pb.EnvironmentGetOrCreateResponse, error) {
+	m.callCount.Add(1)
+	if resp, ok := m.envs.Load(req.GetDeploymentName()); ok {
+		return resp.(*pb.EnvironmentGetOrCreateResponse), nil
+	}
+	return pb.EnvironmentGetOrCreateResponse_builder{
+		EnvironmentId: "en-default",
+		Metadata: pb.EnvironmentMetadata_builder{
+			Name: "",
+			Settings: pb.EnvironmentSettings_builder{
+				ImageBuilderVersion: "2024.10",
+				WebhookSuffix:       "",
+			}.Build(),
+		}.Build(),
+	}.Build(), nil
+}
+
+func (m *mockEnvironmentClient) AuthTokenGet(ctx context.Context, req *pb.AuthTokenGetRequest, opts ...grpc.CallOption) (*pb.AuthTokenGetResponse, error) {
+	return pb.AuthTokenGetResponse_builder{
+		Token: "test-token",
+	}.Build(), nil
+}
+
+func (m *mockEnvironmentClient) getCallCount() int {
+	return int(m.callCount.Load())
+}
+
+func TestGetEnvironmentCached(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	mockClient := &mockEnvironmentClient{}
+	mockClient.envs.Store("", pb.EnvironmentGetOrCreateResponse_builder{
+		EnvironmentId: "en-test123",
+		Metadata: pb.EnvironmentMetadata_builder{
+			Name: "main",
+			Settings: pb.EnvironmentSettings_builder{
+				ImageBuilderVersion: "2024.10",
+				WebhookSuffix:       "modal.run",
+			}.Build(),
+		}.Build(),
+	}.Build())
+	mockClient.envs.Store("dev", pb.EnvironmentGetOrCreateResponse_builder{
+		EnvironmentId: "en-dev",
+		Metadata: pb.EnvironmentMetadata_builder{
+			Name: "dev",
+			Settings: pb.EnvironmentSettings_builder{
+				ImageBuilderVersion: "2025.06",
+			}.Build(),
+		}.Build(),
+	}.Build())
+
+	client, err := NewClientWithOptions(&ClientParams{ControlPlaneClient: mockClient})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	defer client.Close()
+
+	env, err := client.fetchEnvironment(ctx, "")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(env.Settings.ImageBuilderVersion).Should(gomega.Equal("2024.10"))
+	g.Expect(env.Settings.WebhookSuffix).Should(gomega.Equal("modal.run"))
+	g.Expect(mockClient.getCallCount()).Should(gomega.Equal(1))
+
+	env2, err := client.fetchEnvironment(ctx, "")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(env2).Should(gomega.BeIdenticalTo(env))
+	g.Expect(mockClient.getCallCount()).Should(gomega.Equal(1)) // got "" from cache
+
+	envDev, err := client.fetchEnvironment(ctx, "dev")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(envDev.Settings.ImageBuilderVersion).Should(gomega.Equal("2025.06"))
+	g.Expect(mockClient.getCallCount()).Should(gomega.Equal(2)) // got "dev" from server
+}
+
+func TestImageBuilderVersion_LocalConfigHasPrecedence(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	mockClient := &mockEnvironmentClient{}
+	mockClient.envs.Store("", pb.EnvironmentGetOrCreateResponse_builder{
+		EnvironmentId: "en-test",
+		Metadata: pb.EnvironmentMetadata_builder{
+			Settings: pb.EnvironmentSettings_builder{
+				ImageBuilderVersion: "2024.10",
+			}.Build(),
+		}.Build(),
+	}.Build())
+
+	client, err := NewClientWithOptions(&ClientParams{
+		ControlPlaneClient: mockClient,
+		Config: &config{
+			"default": rawProfile{
+				ImageBuilderVersion: "2024.04",
+				Active:              true,
+			},
+		},
+	})
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	defer client.Close()
+
+	version, err := client.imageBuilderVersion(ctx, "")
+	g.Expect(err).ShouldNot(gomega.HaveOccurred())
+	g.Expect(version).Should(gomega.Equal("2024.04"))
+	g.Expect(mockClient.getCallCount()).Should(gomega.Equal(0))
+}

--- a/modal-go/environment_test.go
+++ b/modal-go/environment_test.go
@@ -11,6 +11,14 @@ import (
 	"google.golang.org/grpc"
 )
 
+// mockAuthTokenResponse returns a mock AuthTokenGetResponse with a JWT that has a far-future
+// expiration time. The JWT structure is: mock header + base64({"exp":9999999999}) + mock signature.
+// This prevents warnings from AuthTokenManager.FetchToken() which expects an "exp" field.
+func mockAuthTokenResponse() (*pb.AuthTokenGetResponse, error) {
+	const mockJWT = "x.eyJleHAiOjk5OTk5OTk5OTl9.x"
+	return pb.AuthTokenGetResponse_builder{Token: mockJWT}.Build(), nil
+}
+
 type mockEnvironmentClient struct {
 	pb.ModalClientClient
 	callCount atomic.Int64
@@ -35,9 +43,7 @@ func (m *mockEnvironmentClient) EnvironmentGetOrCreate(ctx context.Context, req 
 }
 
 func (m *mockEnvironmentClient) AuthTokenGet(ctx context.Context, req *pb.AuthTokenGetRequest, opts ...grpc.CallOption) (*pb.AuthTokenGetResponse, error) {
-	return pb.AuthTokenGetResponse_builder{
-		Token: "test-token",
-	}.Build(), nil
+	return mockAuthTokenResponse()
 }
 
 func (m *mockEnvironmentClient) getCallCount() int {

--- a/modal-go/environment_test.go
+++ b/modal-go/environment_test.go
@@ -51,9 +51,10 @@ func (m *mockEnvironmentClient) getCallCount() int {
 }
 
 func TestGetEnvironmentCached(t *testing.T) {
-	t.Parallel()
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
+
+	t.Setenv("MODAL_IMAGE_BUILDER_VERSION", "")
 
 	mockClient := &mockEnvironmentClient{}
 	mockClient.envs.Store("", pb.EnvironmentGetOrCreateResponse_builder{

--- a/modal-go/function.go
+++ b/modal-go/function.go
@@ -86,7 +86,7 @@ func (s *functionServiceImpl) FromName(ctx context.Context, appName string, name
 	resp, err := s.client.cpClient.FunctionGet(ctx, pb.FunctionGetRequest_builder{
 		AppName:         appName,
 		ObjectTag:       name,
-		EnvironmentName: environmentName(params.Environment, s.client.profile),
+		EnvironmentName: firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 
 	if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -231,7 +231,7 @@ func (image *Image) Build(ctx context.Context, app *App) (*Image, error) {
 		}
 	}
 
-	envName := environmentName("", image.client.profile)
+	envName := image.client.profile.Environment
 	builderVersion, err := image.client.imageBuilderVersion(ctx, envName)
 	if err != nil {
 		return nil, err
@@ -239,6 +239,7 @@ func (image *Image) Build(ctx context.Context, app *App) (*Image, error) {
 
 	var currentImageID string
 
+	image.client.logger.DebugContext(ctx, "Starting Image build", "app_id", app.AppID, "builder_version", builderVersion, "env_name", envName)
 	for i, currentLayer := range image.layers {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -225,12 +225,16 @@ func (image *Image) Build(ctx context.Context, app *App) (*Image, error) {
 		return image, nil
 	}
 
-	image.client.logger.DebugContext(ctx, "Building image", "app_id", app.AppID)
-
 	for _, currentLayer := range image.layers {
 		if err := validateDockerfileCommands(currentLayer.commands); err != nil {
 			return nil, err
 		}
+	}
+
+	envName := environmentName("", image.client.profile)
+	builderVersion, err := image.client.imageBuilderVersion(ctx, envName)
+	if err != nil {
+		return nil, err
 	}
 
 	var currentImageID string
@@ -285,7 +289,7 @@ func (image *Image) Build(ctx context.Context, app *App) (*Image, error) {
 					ContextFiles:        []*pb.ImageContextFile{},
 					BaseImages:          baseImages,
 				}.Build(),
-				BuilderVersion: imageBuilderVersion("", image.client.profile),
+				BuilderVersion: builderVersion,
 				ForceBuild:     currentLayer.forceBuild,
 			}.Build(),
 		)

--- a/modal-go/proxy.go
+++ b/modal-go/proxy.go
@@ -34,7 +34,7 @@ func (s *proxyServiceImpl) FromName(ctx context.Context, name string, params *Pr
 
 	resp, err := s.client.cpClient.ProxyGet(ctx, pb.ProxyGetRequest_builder{
 		Name:            name,
-		EnvironmentName: environmentName(params.Environment, s.client.profile),
+		EnvironmentName: firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 
 	if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {

--- a/modal-go/queue.go
+++ b/modal-go/queue.go
@@ -58,7 +58,7 @@ func (s *queueServiceImpl) Ephemeral(ctx context.Context, params *QueueEphemeral
 
 	resp, err := s.client.cpClient.QueueGetOrCreate(ctx, pb.QueueGetOrCreateRequest_builder{
 		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
-		EnvironmentName:    environmentName(params.Environment, s.client.profile),
+		EnvironmentName:    firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (s *queueServiceImpl) FromName(ctx context.Context, name string, params *Qu
 
 	resp, err := s.client.cpClient.QueueGetOrCreate(ctx, pb.QueueGetOrCreateRequest_builder{
 		DeploymentName:     name,
-		EnvironmentName:    environmentName(params.Environment, s.client.profile),
+		EnvironmentName:    firstNonEmpty(params.Environment, s.client.profile.Environment),
 		ObjectCreationType: creationType,
 	}.Build())
 

--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -433,7 +433,7 @@ func (s *sandboxServiceImpl) FromName(ctx context.Context, appName, name string,
 	resp, err := s.client.cpClient.SandboxGetFromName(ctx, pb.SandboxGetFromNameRequest_builder{
 		SandboxName:     name,
 		AppName:         appName,
-		EnvironmentName: environmentName(params.Environment, s.client.profile),
+		EnvironmentName: firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 	if err != nil {
 		if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
@@ -722,7 +722,7 @@ func (sb *Sandbox) SetTags(ctx context.Context, tags map[string]string) error {
 		tagsList = append(tagsList, pb.SandboxTag_builder{TagName: k, TagValue: v}.Build())
 	}
 	_, err := sb.client.cpClient.SandboxTagsSet(ctx, pb.SandboxTagsSetRequest_builder{
-		EnvironmentName: environmentName("", sb.client.profile),
+		EnvironmentName: sb.client.profile.Environment,
 		SandboxId:       sb.SandboxID,
 		Tags:            tagsList,
 	}.Build())
@@ -777,7 +777,7 @@ func (s *sandboxServiceImpl) List(ctx context.Context, params *SandboxListParams
 			resp, err := s.client.cpClient.SandboxList(ctx, pb.SandboxListRequest_builder{
 				AppId:           params.AppID,
 				BeforeTimestamp: before,
-				EnvironmentName: environmentName(params.Environment, s.client.profile),
+				EnvironmentName: firstNonEmpty(params.Environment, s.client.profile.Environment),
 				IncludeFinished: false,
 				Tags:            tagsList,
 			}.Build())

--- a/modal-go/secret.go
+++ b/modal-go/secret.go
@@ -38,7 +38,7 @@ func (s *secretServiceImpl) FromName(ctx context.Context, name string, params *S
 
 	resp, err := s.client.cpClient.SecretGetOrCreate(ctx, pb.SecretGetOrCreateRequest_builder{
 		DeploymentName:  name,
-		EnvironmentName: environmentName(params.Environment, s.client.profile),
+		EnvironmentName: firstNonEmpty(params.Environment, s.client.profile.Environment),
 		RequiredKeys:    params.RequiredKeys,
 	}.Build())
 
@@ -73,7 +73,7 @@ func (s *secretServiceImpl) FromMap(ctx context.Context, keyValuePairs map[strin
 	resp, err := s.client.cpClient.SecretGetOrCreate(ctx, pb.SecretGetOrCreateRequest_builder{
 		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
 		EnvDict:            keyValuePairs,
-		EnvironmentName:    environmentName(params.Environment, s.client.profile),
+		EnvironmentName:    firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 	if err != nil {
 		return nil, err

--- a/modal-go/test/image_test.go
+++ b/modal-go/test/image_test.go
@@ -287,6 +287,20 @@ func TestDockerfileCommandsWithOptions(t *testing.T) {
 	mock := newGRPCMockClient(t)
 
 	grpcmock.HandleUnary(
+		mock, "EnvironmentGetOrCreate",
+		func(req *pb.EnvironmentGetOrCreateRequest) (*pb.EnvironmentGetOrCreateResponse, error) {
+			return pb.EnvironmentGetOrCreateResponse_builder{
+				EnvironmentId: "env-123",
+				Metadata: pb.EnvironmentMetadata_builder{
+					Settings: pb.EnvironmentSettings_builder{
+						ImageBuilderVersion: "2024.10",
+					}.Build(),
+				}.Build(),
+			}.Build(), nil
+		},
+	)
+
+	grpcmock.HandleUnary(
 		mock, "ImageGetOrCreate",
 		func(req *pb.ImageGetOrCreateRequest) (*pb.ImageGetOrCreateResponse, error) {
 			image := req.GetImage()

--- a/modal-go/test/image_test.go
+++ b/modal-go/test/image_test.go
@@ -51,7 +51,8 @@ func TestImageFromRegistryWithSecret(t *testing.T) {
 	// https://cloud.google.com/artifact-registry/docs/docker/authentication#json-key
 	// So we use GCP Artifact Registry to test this too.
 
-	t.Parallel()
+	t.Setenv("MODAL_IMAGE_BUILDER_VERSION", "2024.10")
+
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 	tc := newTestClient(t)
@@ -72,7 +73,8 @@ func TestImageFromRegistryWithSecret(t *testing.T) {
 }
 
 func TestImageFromAwsEcr(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MODAL_IMAGE_BUILDER_VERSION", "2024.10")
+
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 	tc := newTestClient(t)
@@ -91,7 +93,8 @@ func TestImageFromAwsEcr(t *testing.T) {
 }
 
 func TestImageFromGcpArtifactRegistry(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MODAL_IMAGE_BUILDER_VERSION", "2024.10")
+
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 	tc := newTestClient(t)
@@ -280,25 +283,12 @@ func TestDockerfileCommandsCopyCommandValidation(t *testing.T) {
 }
 
 func TestDockerfileCommandsWithOptions(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MODAL_IMAGE_BUILDER_VERSION", "2024.10")
+
 	g := gomega.NewWithT(t)
 	ctx := context.Background()
 
 	mock := newGRPCMockClient(t)
-
-	grpcmock.HandleUnary(
-		mock, "EnvironmentGetOrCreate",
-		func(req *pb.EnvironmentGetOrCreateRequest) (*pb.EnvironmentGetOrCreateResponse, error) {
-			return pb.EnvironmentGetOrCreateResponse_builder{
-				EnvironmentId: "env-123",
-				Metadata: pb.EnvironmentMetadata_builder{
-					Settings: pb.EnvironmentSettings_builder{
-						ImageBuilderVersion: "2024.10",
-					}.Build(),
-				}.Build(),
-			}.Build(), nil
-		},
-	)
 
 	grpcmock.HandleUnary(
 		mock, "ImageGetOrCreate",

--- a/modal-go/test/sandbox_test.go
+++ b/modal-go/test/sandbox_test.go
@@ -820,6 +820,21 @@ func TestSandboxExperimentalDockerMock(t *testing.T) {
 		},
 	)
 
+	grpcmock.HandleUnary(
+		mock, "EnvironmentGetOrCreate",
+		func(req *pb.EnvironmentGetOrCreateRequest) (*pb.EnvironmentGetOrCreateResponse, error) {
+			return pb.EnvironmentGetOrCreateResponse_builder{
+				EnvironmentId: "en-test",
+				Metadata: pb.EnvironmentMetadata_builder{
+					Name: "test",
+					Settings: pb.EnvironmentSettings_builder{
+						ImageBuilderVersion: "2024.10",
+					}.Build(),
+				}.Build(),
+			}.Build(), nil
+		},
+	)
+
 	ctx := context.Background()
 	app, err := mock.Apps.FromName(ctx, "libmodal-test", &modal.AppFromNameParams{CreateIfMissing: true})
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/modal-go/volume.go
+++ b/modal-go/volume.go
@@ -45,7 +45,7 @@ func (s *volumeServiceImpl) FromName(ctx context.Context, name string, params *V
 
 	resp, err := s.client.cpClient.VolumeGetOrCreate(ctx, pb.VolumeGetOrCreateRequest_builder{
 		DeploymentName:     name,
-		EnvironmentName:    environmentName(params.Environment, s.client.profile),
+		EnvironmentName:    firstNonEmpty(params.Environment, s.client.profile.Environment),
 		ObjectCreationType: creationType,
 	}.Build())
 
@@ -94,7 +94,7 @@ func (s *volumeServiceImpl) Ephemeral(ctx context.Context, params *VolumeEphemer
 
 	resp, err := s.client.cpClient.VolumeGetOrCreate(ctx, pb.VolumeGetOrCreateRequest_builder{
 		ObjectCreationType: pb.ObjectCreationType_OBJECT_CREATION_TYPE_EPHEMERAL,
-		EnvironmentName:    environmentName(params.Environment, s.client.profile),
+		EnvironmentName:    firstNonEmpty(params.Environment, s.client.profile.Environment),
 	}.Build())
 	if err != nil {
 		return nil, err

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -29,6 +29,19 @@ import { getSDKVersion } from "./version";
 import { checkForRenamedParams } from "./validation";
 import { createLogger, type Logger, type LogLevel } from "./logger";
 
+/** Represents a Modal Environment with its server-provided settings. */
+interface Environment {
+  id: string;
+  name: string;
+  settings: EnvironmentSettings;
+}
+
+/** Environment-scoped configuration from the server. */
+interface EnvironmentSettings {
+  imageBuilderVersion: string;
+  webhookSuffix: string;
+}
+
 export interface ModalClientParams {
   tokenId?: string;
   tokenSecret?: string;
@@ -96,6 +109,8 @@ export class ModalClient {
   private ipClients: Map<string, ModalGrpcClient>;
   private authTokenManager: AuthTokenManager | null = null;
   private customMiddleware: ClientMiddleware[];
+  private environmentsCache: Map<string, Environment>;
+  private environmentFetchPromises: Map<string, Promise<Environment>>;
 
   constructor(params?: ModalClientParams) {
     checkForRenamedParams(params, { timeout: "timeoutMs" });
@@ -120,6 +135,8 @@ export class ModalClient {
 
     this.customMiddleware = params?.grpcMiddleware ?? [];
     this.ipClients = new Map();
+    this.environmentsCache = new Map();
+    this.environmentFetchPromises = new Map();
     this.cpClient = params?.cpClient ?? this.createClient(this.profile);
 
     this.logger.debug("Modal client initialized successfully");
@@ -141,8 +158,74 @@ export class ModalClient {
     return environment || this.profile.environment || "";
   }
 
-  imageBuilderVersion(version?: string): string {
-    return version || this.profile.imageBuilderVersion || "2024.10";
+  /**
+   * Fetches an environment from the server, caching the result.
+   * Pass undefined for name to get the default environment.
+   */
+  private async fetchEnvironment(name?: string): Promise<Environment> {
+    const cacheKey = name ?? "";
+    const cached = this.environmentsCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const inProgress = this.environmentFetchPromises.get(cacheKey);
+    if (inProgress) {
+      return inProgress;
+    }
+
+    const promise = this.doFetchEnvironment(name);
+    this.environmentFetchPromises.set(cacheKey, promise);
+
+    try {
+      const env = await promise;
+      this.environmentsCache.set(cacheKey, env);
+      return env;
+    } finally {
+      this.environmentFetchPromises.delete(cacheKey);
+    }
+  }
+
+  private async doFetchEnvironment(name?: string): Promise<Environment> {
+    this.logger.debug("Fetching environment from server", "environment_name", name ?? "");
+
+    const resp = await this.cpClient.environmentGetOrCreate({
+      deploymentName: name ?? "",
+    });
+
+    const metadata = resp.metadata!;
+    const settings = metadata.settings!;
+
+    const env: Environment = {
+      id: resp.environmentId,
+      name: metadata.name,
+      settings: {
+        imageBuilderVersion: settings.imageBuilderVersion,
+        webhookSuffix: settings.webhookSuffix,
+      },
+    };
+
+    this.logger.debug(
+      "Cached environment",
+      "environment_name", name,
+      "environment_id", env.id,
+      "image_builder_version", env.settings.imageBuilderVersion,
+    );
+
+    return env;
+  }
+
+  /**
+   * Returns the image builder version to use for image builds.
+   * Precedence: local config > server-provided value.
+   */
+  async getImageBuilderVersion(): Promise<string> {
+    if (this.profile.imageBuilderVersion) {
+      return this.profile.imageBuilderVersion;
+    }
+
+    const env = await this.fetchEnvironment(this.profile.environment);
+    return env.settings.imageBuilderVersion;
   }
 
   /** @ignore */

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -187,7 +187,11 @@ export class ModalClient {
   }
 
   private async doFetchEnvironment(name?: string): Promise<Environment> {
-    this.logger.debug("Fetching environment from server", "environment_name", name ?? "");
+    this.logger.debug(
+      "Fetching environment from server",
+      "environment_name",
+      name ?? "",
+    );
 
     const resp = await this.cpClient.environmentGetOrCreate({
       deploymentName: name ?? "",
@@ -207,9 +211,12 @@ export class ModalClient {
 
     this.logger.debug(
       "Cached environment",
-      "environment_name", name,
-      "environment_id", env.id,
-      "image_builder_version", env.settings.imageBuilderVersion,
+      "environment_name",
+      name,
+      "environment_id",
+      env.id,
+      "image_builder_version",
+      env.settings.imageBuilderVersion,
     );
 
     return env;

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -197,15 +197,12 @@ export class ModalClient {
       deploymentName: name ?? "",
     });
 
-    const metadata = resp.metadata!;
-    const settings = metadata.settings!;
-
     const env: Environment = {
       id: resp.environmentId,
-      name: metadata.name,
+      name: resp.metadata?.name ?? "",
       settings: {
-        imageBuilderVersion: settings.imageBuilderVersion,
-        webhookSuffix: settings.webhookSuffix,
+        imageBuilderVersion: resp.metadata?.settings?.imageBuilderVersion ?? "",
+        webhookSuffix: resp.metadata?.settings?.webhookSuffix ?? "",
       },
     };
 

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -281,7 +281,18 @@ export class Image {
       return this;
     }
 
-    this.#client.logger.debug("Building image", "app_id", app.appId);
+    const envName = this.#client.profile.environment || "";
+    const builderVersion = await this.#client.getImageBuilderVersion();
+
+    this.#client.logger.debug(
+      "Starting Image build",
+      "app_id",
+      app.appId,
+      "builder_version",
+      builderVersion,
+      "env_name",
+      envName,
+    );
 
     let baseImageId: string | undefined;
 
@@ -318,7 +329,7 @@ export class Image {
           contextFiles: [],
           baseImages,
         }),
-        builderVersion: this.#client.imageBuilderVersion(),
+        builderVersion,
         forceBuild: layer.forceBuild || false,
       });
 

--- a/modal-js/test/environment.test.ts
+++ b/modal-js/test/environment.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "vitest";
+import { ModalClient } from "../src/client";
+import { MockGrpcClient } from "../test-support/grpc_mock";
+
+function createTestJWT(exp: number): string {
+  const header = "x";
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64");
+  const signature = "x";
+  return `${header}.${payload}.${signature}`;
+}
+
+function createMockEnvironmentClient(): {
+  mockClient: ModalClient;
+  mock: MockGrpcClient;
+  getCallCount: () => number;
+} {
+  let callCount = 0;
+  const mock = new MockGrpcClient();
+
+  mock.handleUnary("/AuthTokenGet", () => {
+    return { token: createTestJWT(9999999999) };
+  });
+
+  const originalHandleUnary = mock.handleUnary.bind(mock);
+  mock.handleUnary = (rpcName: string, handler: any) => {
+    if (rpcName === "/EnvironmentGetOrCreate") {
+      originalHandleUnary(rpcName, (req: any) => {
+        callCount++;
+        return handler(req);
+      });
+    } else {
+      originalHandleUnary(rpcName, handler);
+    }
+  };
+
+  const mockClient = new ModalClient({
+    cpClient: mock as any,
+    tokenId: "test-token-id",
+    tokenSecret: "test-token-secret",
+  });
+
+  return {
+    mockClient,
+    mock,
+    getCallCount: () => callCount,
+  };
+}
+
+test("GetEnvironmentCached", async () => {
+  const { mockClient, mock, getCallCount } = createMockEnvironmentClient();
+
+  mock.handleUnary("/EnvironmentGetOrCreate", () => {
+    return {
+      environmentId: "en-test123",
+      metadata: {
+        name: "main",
+        settings: {
+          imageBuilderVersion: "2024.10",
+          webhookSuffix: "modal.run",
+        },
+      },
+    };
+  });
+
+  const version1 = await mockClient.getImageBuilderVersion();
+  expect(version1).toBe("2024.10");
+  expect(getCallCount()).toBe(1);
+
+  const version2 = await mockClient.getImageBuilderVersion();
+  expect(version2).toBe("2024.10");
+  expect(getCallCount()).toBe(1); // got "" from cache
+
+  const { mockClient: mockClientDev, mock: mockDev } = createMockEnvironmentClient();
+
+  mockDev.handleUnary("/EnvironmentGetOrCreate", () => {
+    return {
+      environmentId: "en-dev",
+      metadata: {
+        name: "dev",
+        settings: {
+          imageBuilderVersion: "2025.06",
+          webhookSuffix: "",
+        },
+      },
+    };
+  });
+
+  // Create a new client with "dev" environment
+  const newMockClientDev = new ModalClient({
+    cpClient: mockDev as any,
+    tokenId: "test-token-id",
+    tokenSecret: "test-token-secret",
+    environment: "dev",
+  });
+
+  const versionDev = await newMockClientDev.getImageBuilderVersion();
+  expect(versionDev).toBe("2025.06");
+
+  mockClient.close();
+  mockClientDev.close();
+  newMockClientDev.close();
+});
+
+test("ImageBuilderVersion_LocalConfigHasPrecedence", async () => {
+  const { mockClient, mock, getCallCount } = createMockEnvironmentClient();
+
+  mock.handleUnary("/EnvironmentGetOrCreate", () => {
+    return {
+      environmentId: "en-test",
+      metadata: {
+        name: "",
+        settings: {
+          imageBuilderVersion: "2024.10",
+          webhookSuffix: "",
+        },
+      },
+    };
+  });
+
+  const mockClientWithConfig = new ModalClient({
+    cpClient: mock as any,
+    tokenId: "test-token-id",
+    tokenSecret: "test-token-secret",
+  });
+
+  mockClientWithConfig.profile.imageBuilderVersion = "2024.04";
+
+  const version = await mockClientWithConfig.getImageBuilderVersion();
+  expect(version).toBe("2024.04");
+  expect(getCallCount()).toBe(0); // should not fetch from server
+
+  mockClient.close();
+  mockClientWithConfig.close();
+});

--- a/modal-js/test/environment.test.ts
+++ b/modal-js/test/environment.test.ts
@@ -73,7 +73,8 @@ test("GetEnvironmentCached", async () => {
   expect(version2).toBe("2024.10");
   expect(getCallCount()).toBe(1); // got "" from cache
 
-  const { mockClient: mockClientDev, mock: mockDev } = createMockEnvironmentClient();
+  const { mockClient: mockClientDev, mock: mockDev } =
+    createMockEnvironmentClient();
 
   mockDev.handleUnary("/EnvironmentGetOrCreate", () => {
     return {

--- a/modal-js/test/environment.test.ts
+++ b/modal-js/test/environment.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { ModalClient } from "../src/client";
 import { MockGrpcClient } from "../test-support/grpc_mock";
 
@@ -47,6 +47,9 @@ function createMockEnvironmentClient(): {
 }
 
 test("GetEnvironmentCached", async () => {
+  // Temporarily unset the env var so we fetch from server
+  vi.stubEnv("MODAL_IMAGE_BUILDER_VERSION", undefined);
+
   const { mockClient, mock, getCallCount } = createMockEnvironmentClient();
 
   mock.handleUnary("/EnvironmentGetOrCreate", () => {
@@ -99,6 +102,8 @@ test("GetEnvironmentCached", async () => {
   mockClient.close();
   mockClientDev.close();
   newMockClientDev.close();
+
+  vi.unstubAllEnvs();
 });
 
 test("ImageBuilderVersion_LocalConfigHasPrecedence", async () => {

--- a/modal-js/test/image.test.ts
+++ b/modal-js/test/image.test.ts
@@ -201,6 +201,19 @@ test("DockerfileCommandsCopyCommandValidation", () => {
 test("DockerfileCommandsWithOptions", async () => {
   const { mockClient: mc, mockCpClient: mock } = createMockModalClients();
 
+  mock.handleUnary("/EnvironmentGetOrCreate", () => {
+    return {
+      environmentId: "env-123",
+      metadata: {
+        name: "",
+        settings: {
+          imageBuilderVersion: "2024.10",
+          webhookSuffix: "",
+        },
+      },
+    };
+  });
+
   mock.handleUnary("/ImageGetOrCreate", (req: any) => {
     expect(req).toMatchObject({
       appId: "ap-test",

--- a/modal-js/test/image.test.ts
+++ b/modal-js/test/image.test.ts
@@ -201,19 +201,6 @@ test("DockerfileCommandsCopyCommandValidation", () => {
 test("DockerfileCommandsWithOptions", async () => {
   const { mockClient: mc, mockCpClient: mock } = createMockModalClients();
 
-  mock.handleUnary("/EnvironmentGetOrCreate", () => {
-    return {
-      environmentId: "env-123",
-      metadata: {
-        name: "",
-        settings: {
-          imageBuilderVersion: "2024.10",
-          webhookSuffix: "",
-        },
-      },
-    };
-  });
-
   mock.handleUnary("/ImageGetOrCreate", (req: any) => {
     expect(req).toMatchObject({
       appId: "ap-test",

--- a/modal-js/test/legacy/image.test.ts
+++ b/modal-js/test/legacy/image.test.ts
@@ -251,6 +251,19 @@ test("DockerfileCommandsCopyCommandValidation", () => {
 test("DockerfileCommandsWithOptions", async () => {
   const { mockClient: mc, mockCpClient: mock } = createMockModalClients();
 
+  mock.handleUnary("/EnvironmentGetOrCreate", () => {
+    return {
+      environmentId: "env-123",
+      metadata: {
+        name: "",
+        settings: {
+          imageBuilderVersion: "2024.10",
+          webhookSuffix: "",
+        },
+      },
+    };
+  });
+
   mock.handleUnary("/ImageGetOrCreate", (req: any) => {
     expect(req).toMatchObject({
       appId: "ap-test",

--- a/modal-js/test/legacy/image.test.ts
+++ b/modal-js/test/legacy/image.test.ts
@@ -251,19 +251,6 @@ test("DockerfileCommandsCopyCommandValidation", () => {
 test("DockerfileCommandsWithOptions", async () => {
   const { mockClient: mc, mockCpClient: mock } = createMockModalClients();
 
-  mock.handleUnary("/EnvironmentGetOrCreate", () => {
-    return {
-      environmentId: "env-123",
-      metadata: {
-        name: "",
-        settings: {
-          imageBuilderVersion: "2024.10",
-          webhookSuffix: "",
-        },
-      },
-    };
-  });
-
   mock.handleUnary("/ImageGetOrCreate", (req: any) => {
     expect(req).toMatchObject({
       appId: "ap-test",

--- a/modal-js/vitest.config.ts
+++ b/modal-js/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     slowTestThreshold: 5_000,
     testTimeout: 20_000,
     reporters: ["verbose"],
+    env: {
+      MODAL_IMAGE_BUILDER_VERSION: "2024.10", // TODO: temporary until we've fixed the build env for tests
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Both SDKs now fetch and cache environment settings and use the server-provided Image Builder Version for image builds, replacing hardcoded defaults and updating calls to pass the resolved environment.
> 
> - **Breaking change**:
>   - SDKs read Image Builder Version from account settings instead of defaulting to `2024.10` (may trigger one rebuild on first run).
> - **Go SDK**:
>   - **Environment settings**: Add `environment.go` with `Environment` model, cached fetch (`sync.Map` + `singleflight`) via `EnvironmentGetOrCreate` and `imageBuilderVersion(ctx, env)`.
>   - **Image builds**: `Image.Build()` uses server-derived `builderVersion` and logs `builder_version`/`env_name`.
>   - **Environment resolution**: Replace `environmentName()` with `firstNonEmpty(..., profile.Environment)` across services (`Apps`, `Cls`, `Functions`, `Proxy`, `Queue`, `Volume`, `Sandbox`, `Secret`).
>   - **Client**: Track `environmentsCache` and `environmentGroup`.
> - **JS SDK**:
>   - **Environment settings**: Add environment fetch/caching in `ModalClient` (`fetchEnvironment`, `getImageBuilderVersion`) via `environmentGetOrCreate`.
>   - **Image builds**: `Image.build()` uses server-derived `builderVersion` and logs `builder_version`/`env_name`.
> - **Tests**:
>   - Add environment caching/precedence tests in Go and JS.
>   - Update image-related tests to set `MODAL_IMAGE_BUILDER_VERSION` where needed; vitest sets default env var.
> - **Docs**:
>   - Update `CHANGELOG.md` to note breaking change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b65b047159bee267e9cef414c3d4a71d33816e78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->