### PR TITLE
Add support for forcing re-build of Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
-No unreleased changes.
+- Added an optional `forceBuild` parameter to `images.fromRegistry`, `images.fromAwsEcr`, `images.fromGcpArtifactRegistry`, and `Image.build` to the JS SDK.
+
+**Breaking changes:**
+- Added `...Params` struct arguments, and an optional `ForceBuild` parameter, to `Images.FromRegistry`, `Images.FromAwsEcr`, `Images.FromGcpArtifactRegistry`, and `Image.Build` to the Go SDK.
 
 ## modal-js/v0.6.0, modal-go/v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Both client libraries are pre-1.0, and they have separate versioning.
 
 ## Unreleased
 
-- Added an optional `forceBuild` parameter to `images.fromRegistry`, `images.fromAwsEcr`, `images.fromGcpArtifactRegistry`, and `Image.build` to the JS SDK.
 - Added support for the `MODAL_FORCE_BUILD` environment variable and `force_build` config option for `modal.toml`. When set, this applies to all image builds.
+- Added an optional `forceBuild` parameter to `images.fromRegistry`, `images.fromAwsEcr`, `images.fromGcpArtifactRegistry`, and `Image.build` to the JS SDK.
+- Added `secret` field to `ImageFromRegistryParams` in the JS SDK to match the Go SDK pattern. The separate `secret` parameter in `images.fromRegistry()` is now deprecated.
 
 **Breaking changes:**
 - Added `...Params` struct arguments, and an optional `ForceBuild` parameter, to `Images.FromRegistry`, `Images.FromAwsEcr`, `Images.FromGcpArtifactRegistry`, and `Image.Build` to the Go SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Both client libraries are pre-1.0, and they have separate versioning.
 ## Unreleased
 
 - Added an optional `forceBuild` parameter to `images.fromRegistry`, `images.fromAwsEcr`, `images.fromGcpArtifactRegistry`, and `Image.build` to the JS SDK.
+- Added support for the `MODAL_FORCE_BUILD` environment variable and `force_build` config option for `modal.toml`. When set, this applies to all image builds.
 
 **Breaking changes:**
 - Added `...Params` struct arguments, and an optional `ForceBuild` parameter, to `Images.FromRegistry`, `Images.FromAwsEcr`, `Images.FromGcpArtifactRegistry`, and `Image.Build` to the Go SDK.

--- a/modal-go/config.go
+++ b/modal-go/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -20,6 +21,7 @@ type Profile struct {
 	Environment         string
 	ImageBuilderVersion string
 	LogLevel            string
+	ForceBuild          bool
 }
 
 // rawProfile mirrors the TOML structure on disk.
@@ -30,6 +32,7 @@ type rawProfile struct {
 	Environment         string `toml:"environment"`
 	ImageBuilderVersion string `toml:"image_builder_version"`
 	LogLevel            string `toml:"loglevel"`
+	ForceBuild          bool   `toml:"force_build"`
 	Active              bool   `toml:"active"`
 }
 
@@ -95,6 +98,7 @@ func getProfile(name string, cfg config) Profile {
 	environment := firstNonEmpty(os.Getenv("MODAL_ENVIRONMENT"), raw.Environment)
 	imageBuilderVersion := firstNonEmpty(os.Getenv("MODAL_IMAGE_BUILDER_VERSION"), raw.ImageBuilderVersion)
 	logLevel := firstNonEmpty(os.Getenv("MODAL_LOGLEVEL"), raw.LogLevel)
+	forceBuild := envBool("MODAL_FORCE_BUILD") || raw.ForceBuild
 
 	return Profile{
 		ServerURL:           serverURL,
@@ -103,6 +107,7 @@ func getProfile(name string, cfg config) Profile {
 		Environment:         environment,
 		ImageBuilderVersion: imageBuilderVersion,
 		LogLevel:            logLevel,
+		ForceBuild:          forceBuild,
 	}
 }
 
@@ -113,6 +118,11 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func envBool(key string) bool {
+	v := strings.ToLower(os.Getenv(key))
+	return v != "" && v != "0" && v != "false"
 }
 
 func environmentName(environment string, profile Profile) string {

--- a/modal-go/examples/sandbox-prewarm/main.go
+++ b/modal-go/examples/sandbox-prewarm/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	// With `.Build(app)`, we create an Image object on Modal that eagerly pulls
 	// from the registry.
-	image, err := mc.Images.FromRegistry("alpine:3.21", nil).Build(ctx, app)
+	image, err := mc.Images.FromRegistry("alpine:3.21", nil).Build(ctx, app, nil)
 	if err != nil {
 		log.Fatalf("Unable to build Image: %v", err)
 	}

--- a/modal-go/examples/sandbox-private-image/main.go
+++ b/modal-go/examples/sandbox-private-image/main.go
@@ -28,7 +28,7 @@ func main() {
 		log.Fatalf("Failed to get Secret: %v", err)
 	}
 
-	image := mc.Images.FromAwsEcr("459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python", secret)
+	image := mc.Images.FromAwsEcr("459781239556.dkr.ecr.us-east-1.amazonaws.com/ecr-private-registry-test-7522615:python", secret, nil)
 
 	sb, err := mc.Sandboxes.Create(ctx, app, image, &modal.SandboxCreateParams{
 		Command: []string{"python", "-c", `import sys; sys.stdout.write(sys.stdin.read())`},

--- a/modal-go/sandbox.go
+++ b/modal-go/sandbox.go
@@ -288,7 +288,7 @@ func (s *sandboxServiceImpl) Create(ctx context.Context, app *App, image *Image,
 		params = &SandboxCreateParams{}
 	}
 
-	image, err := image.Build(ctx, app)
+	image, err := image.Build(ctx, app, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/modal-js/src/app.ts
+++ b/modal-js/src/app.ts
@@ -135,7 +135,7 @@ export class App {
    * @deprecated Use {@link ImageService#fromRegistry client.images.fromRegistry()} instead.
    */
   async imageFromRegistry(tag: string, secret?: Secret): Promise<Image> {
-    return getDefaultClient().images.fromRegistry(tag, secret).build(this);
+    return getDefaultClient().images.fromRegistry(tag, { secret }).build(this);
   }
 
   /**

--- a/modal-js/src/config.ts
+++ b/modal-js/src/config.ts
@@ -13,6 +13,7 @@ interface Config {
     environment?: string;
     imageBuilderVersion?: string;
     loglevel?: string;
+    force_build?: boolean;
     active?: boolean;
   };
 }
@@ -25,6 +26,7 @@ export interface Profile {
   environment?: string;
   imageBuilderVersion?: string;
   logLevel?: string;
+  forceBuild?: boolean;
 }
 
 export function configFilePath(): string {
@@ -59,6 +61,12 @@ function readConfigFile(): Config {
 // synchronously, for instance.
 const config: Config = readConfigFile();
 
+function toBoolean(value: string | undefined): boolean {
+  if (!value) return false;
+  const lower = value.toLowerCase();
+  return lower !== "" && lower !== "0" && lower !== "false";
+}
+
 export function getProfile(profileName?: string): Profile {
   if (!profileName) {
     for (const [name, profileData] of Object.entries(config)) {
@@ -85,6 +93,8 @@ export function getProfile(profileName?: string): Profile {
       process.env["MODAL_IMAGE_BUILDER_VERSION"] ||
       profileData.imageBuilderVersion,
     logLevel: process.env["MODAL_LOGLEVEL"] || profileData.loglevel,
+    forceBuild:
+      toBoolean(process.env["MODAL_FORCE_BUILD"]) || profileData.force_build,
   };
   return profile as Profile; // safe to null-cast because of check above
 }

--- a/modal-js/src/image.ts
+++ b/modal-js/src/image.ts
@@ -359,7 +359,11 @@ export class Image {
     this.#client.logger.debug("Building image", "app_id", app.appId);
 
     let baseImageId: string | undefined;
-    let forceBuild = this.#forceBuild || params?.forceBuild || false;
+    let forceBuild =
+      this.#client.profile.forceBuild ||
+      this.#forceBuild ||
+      params?.forceBuild ||
+      false;
 
     for (let i = 0; i < this.#layers.length; i++) {
       const layer = this.#layers[i];

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -55,8 +55,12 @@ export {
 export {
   Image,
   ImageService,
+  type ImageBuildParams,
   type ImageDeleteParams,
   type ImageDockerfileCommandsParams,
+  type ImageFromAwsEcrParams,
+  type ImageFromGcpArtifactRegistryParams,
+  type ImageFromRegistryParams,
 } from "./image";
 export { Retries } from "./retries";
 export type {

--- a/modal-js/test/image.test.ts
+++ b/modal-js/test/image.test.ts
@@ -41,9 +41,14 @@ test("ImageFromRegistryWithSecret", async () => {
   const image = await tc.images
     .fromRegistry(
       "us-east1-docker.pkg.dev/modal-prod-367916/private-repo-test/my-image",
-      await tc.secrets.fromName("libmodal-gcp-artifact-registry-test", {
-        requiredKeys: ["REGISTRY_USERNAME", "REGISTRY_PASSWORD"],
-      }),
+      {
+        secret: await tc.secrets.fromName(
+          "libmodal-gcp-artifact-registry-test",
+          {
+            requiredKeys: ["REGISTRY_USERNAME", "REGISTRY_PASSWORD"],
+          },
+        ),
+      },
     )
     .build(app);
   expect(image.imageId).toBeTruthy();
@@ -286,7 +291,7 @@ test.each([
       mc: ReturnType<typeof createMockModalClients>["mockClient"],
     ) =>
       mc.images
-        .fromRegistry("alpine:3.21", undefined, { forceBuild: true })
+        .fromRegistry("alpine:3.21", { forceBuild: true })
         .build(new App("ap-test", "libmodal-test")),
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds force-build support (via MODAL_FORCE_BUILD and modal.toml force_build) and new optional forceBuild params across image APIs in JS/Go; deprecates JS secret arg; breaking: Go image methods now take Params structs.
> 
> - **Config/Profile**
>   - Read global force-build from `MODAL_FORCE_BUILD` env and `force_build` in `~/.modal.toml` (`modal-go/config.go`, `modal-js/src/config.ts`).
> - **Go SDK**
>   - Image APIs accept new params:
>     - `Images.FromRegistry(tag, *ImageFromRegistryParams)` (adds `ForceBuild` and optional `Secret`).
>     - `Images.FromAwsEcr(tag, secret, *ImageFromAwsEcrParams)` and `Images.FromGcpArtifactRegistry(tag, secret, *ImageFromGcpArtifactRegistryParams)` (add `ForceBuild`).
>     - `Image.Build(ctx, app, *ImageBuildParams)` (adds `ForceBuild`).
>   - Force-build is computed from profile/env, image-level, layer-level, and build params; propagates across layers.
>   - Call sites updated (`Sandbox.Create`, examples, tests).
> - **JS SDK**
>   - Add optional `forceBuild` to `images.fromRegistry`, `images.fromAwsEcr`, `images.fromGcpArtifactRegistry`, and `Image.build`.
>   - Add `secret` to `ImageFromRegistryParams`; deprecate separate `secret` arg in `fromRegistry()`; update `App.imageFromRegistry()`/static helpers.
>   - Implement force-build aggregation/propagation (profile/env → image → layers → build param).
>   - Expose new types in `index.ts`.
> - **Tests/Examples**
>   - Add/adjust tests to cover force-build from params, env, and propagation; update examples to new method signatures.
> - **Changelog**
>   - Document new env/config options, JS additions, deprecation, and Go breaking changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e541c549cd6e97bbd360cfa9aa4b846441efa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->