### PR TITLE
Unskip image mount tests

### DIFF
--- a/modal-js/test/sandbox_mount_image.test.ts
+++ b/modal-js/test/sandbox_mount_image.test.ts
@@ -1,7 +1,7 @@
 import { tc } from "../test-support/test-client";
 import { expect, test, onTestFinished } from "vitest";
 
-test.skip("SandboxMountDirectoryEmpty", async () => {
+test("SandboxMountDirectoryEmpty", async () => {
   const app = await tc.apps.fromName("libmodal-test", {
     createIfMissing: true,
   });
@@ -17,7 +17,7 @@ test.skip("SandboxMountDirectoryEmpty", async () => {
   expect(await dirCheck.wait()).toBe(0);
 });
 
-test.skip("SandboxMountDirectoryWithImage", async () => {
+test("SandboxMountDirectoryWithImage", async () => {
   const app = await tc.apps.fromName("libmodal-test", {
     createIfMissing: true,
   });
@@ -49,7 +49,7 @@ test.skip("SandboxMountDirectoryWithImage", async () => {
   expect(output).toBe("mounted content");
 });
 
-test.skip("SandboxSnapshotDirectory", async () => {
+test("SandboxSnapshotDirectory", async () => {
   const app = await tc.apps.fromName("libmodal-test", {
     createIfMissing: true,
   });
@@ -84,7 +84,7 @@ test.skip("SandboxSnapshotDirectory", async () => {
   expect(output).toBe("snapshot test content");
 });
 
-test.skip("SandboxMountDirectoryWithUnbuiltImageThrows", async () => {
+test("SandboxMountDirectoryWithUnbuiltImageThrows", async () => {
   const app = await tc.apps.fromName("libmodal-test", {
     createIfMissing: true,
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unskips and activates sandbox image-mount tests for empty mounts, mounting snapshots/images across sandboxes, and error handling for unbuilt images.
> 
> - **Tests**:
>   - Enable four vitest cases in `modal-js/test/sandbox_mount_image.test.ts`:
>     - `SandboxMountDirectoryEmpty`: mount empty directory and verify it exists.
>     - `SandboxMountDirectoryWithImage`: snapshot filesystem from one sandbox and mount in another; verify file contents.
>     - `SandboxSnapshotDirectory`: snapshot a mounted directory and remount; verify file contents.
>     - `SandboxMountDirectoryWithUnbuiltImageThrows`: assert mounting an unbuilt image rejects with expected error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ac14c7b306bd2dc08c5b3dc80e6a34357478557. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->