### PR TITLE
Fix intermittent RST_STREAM errors by adding gRPC keepalive settings

### DIFF
--- a/modal-go/client.go
+++ b/modal-go/client.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -338,6 +339,11 @@ func newClient(ctx context.Context, profile Profile, c *Client, customUnaryInter
 			grpc.MaxCallRecvMsgSize(maxMessageSize),
 			grpc.MaxCallSendMsgSize(maxMessageSize),
 		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                30 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 	)

--- a/modal-js/src/client.ts
+++ b/modal-js/src/client.ts
@@ -179,6 +179,9 @@ export class ModalClient {
       "grpc.max_receive_message_length": 100 * 1024 * 1024,
       "grpc.max_send_message_length": 100 * 1024 * 1024,
       "grpc-node.flow_control_window": 64 * 1024 * 1024,
+      "grpc.keepalive_time_ms": 30000,
+      "grpc.keepalive_timeout_ms": 10000,
+      "grpc.keepalive_permit_without_calls": 1,
     });
     let factory = createClientFactory()
       .use(this.authMiddleware(profile))


### PR DESCRIPTION
Without keepalive, the client cannot proactively detect degraded HTTP/2 connections. When a connection enters a bad state (e.g. a load balancer resets streams), retry attempts reuse the same broken connection and exhaust the retry budget before @grpc/grpc-js can reconnect. Adding keepalive pings allows the transport to detect dead connections sooner and establish fresh ones for retries.