### PR TITLE
Expose forceBuild on fromRegistry()

### DIFF
--- a/modal-go/image.go
+++ b/modal-go/image.go
@@ -59,7 +59,8 @@ type Image struct {
 
 // ImageFromRegistryParams are options for creating an Image from a registry.
 type ImageFromRegistryParams struct {
-	Secret *Secret // Secret for private registry authentication.
+	Secret     *Secret // Secret for private registry authentication.
+	ForceBuild bool    // Ignore cached builds, similar to 'docker build --no-cache'.
 }
 
 // FromRegistry builds a Modal Image from a public or private image registry without any changes.
@@ -79,7 +80,7 @@ func (s *imageServiceImpl) FromRegistry(tag string, params *ImageFromRegistryPar
 		ImageID:             "",
 		imageRegistryConfig: imageRegistryConfig,
 		tag:                 tag,
-		layers:              []layer{{}},
+		layers:              []layer{{forceBuild: params.ForceBuild}},
 		client:              s.client,
 	}
 }

--- a/modal-js/src/index.ts
+++ b/modal-js/src/index.ts
@@ -57,6 +57,7 @@ export {
   ImageService,
   type ImageDeleteParams,
   type ImageDockerfileCommandsParams,
+  type ImageFromRegistryParams,
 } from "./image";
 export { Retries } from "./retries";
 export type {


### PR DESCRIPTION
## Summary
- Adds `forceBuild` option to `fromRegistry()` in both JS and Go SDKs
- Allows forcing a fresh image pull/rebuild on the base image layer, not just on `dockerfileCommands()` layers
- JS change is backwards compatible: `fromRegistry(tag, secret)` still works alongside `fromRegistry(tag, { secret, forceBuild })`

## Test plan
- [ ] Verify existing image tests pass
- [ ] Test `fromRegistry("alpine", { forceBuild: true })` triggers a fresh build
- [ ] Test `fromRegistry("alpine", secret)` still works (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)