### PR TITLE
Wait for exec before snapshot

### DIFF
--- a/modal-js/test/sandbox_filesystem_snapshot.test.ts
+++ b/modal-js/test/sandbox_filesystem_snapshot.test.ts
@@ -9,10 +9,14 @@ test("snapshotFilesystem", async () => {
 
   const sb = await tc.sandboxes.create(app, image);
 
-  const writeFile = await sb.exec(["sh", "-c", "echo -n 'test content' > /tmp/test.txt"]);
+  const writeFile = await sb.exec([
+    "sh",
+    "-c",
+    "echo -n 'test content' > /tmp/test.txt",
+  ]);
   await writeFile.wait();
-  const mkdir = await sb.exec(["mkdir", "-p", "/tmp/testdir"]);
-  await mkdir.wait();
+  const mkDir = await sb.exec(["mkdir", "-p", "/tmp/testdir"]);
+  await mkDir.wait();
 
   const snapshotImage = await sb.snapshotFilesystem();
   expect(snapshotImage.imageId).toMatch(/^im-/);

--- a/modal-js/test/sandbox_filesystem_snapshot.test.ts
+++ b/modal-js/test/sandbox_filesystem_snapshot.test.ts
@@ -9,8 +9,10 @@ test("snapshotFilesystem", async () => {
 
   const sb = await tc.sandboxes.create(app, image);
 
-  await sb.exec(["sh", "-c", "echo -n 'test content' > /tmp/test.txt"]);
-  await sb.exec(["mkdir", "-p", "/tmp/testdir"]);
+  const writeFile = await sb.exec(["sh", "-c", "echo -n 'test content' > /tmp/test.txt"]);
+  await writeFile.wait();
+  const mkdir = await sb.exec(["mkdir", "-p", "/tmp/testdir"]);
+  await mkdir.wait();
 
   const snapshotImage = await sb.snapshotFilesystem();
   expect(snapshotImage.imageId).toMatch(/^im-/);


### PR DESCRIPTION
This PR fixes the `snapshotFilesystem` flaky test by waiting on the exec.